### PR TITLE
Chore: 테일윈드 색상 디자인 토큰 생성

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,1 +1,27 @@
 @import "tailwindcss";
+
+@theme {
+  --color-gray-1: #ffffff;
+  --color-gray-2: #f5f5f5;
+  --color-gray-3: #dddddd;
+  --color-gray-4: #a6a6a6;
+  --color-gray-5: #666666;
+  --color-gray-6: #222222;
+
+  --color-primary-1: #f2effd;
+  --color-primary-2: #ede6ff;
+  --color-primary-3: #d7cbf7;
+  --color-primary-4: #b69cf1;
+  --color-primary-5: #986be9;
+  --color-primary-6: #7c35d9;
+  --color-primary-7: #522193;
+
+  --color-green: #5eb669;
+  --color-light-green: #37f4e9;
+
+  --color-red: #cc0a0a;
+  --color-pale-pink: #f9e2e2;
+
+  --color-yellow: #f6a818;
+  --color-pale-yellow: #fdeece;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,27 +1,19 @@
 @import "tailwindcss";
 
 @theme {
-  --color-gray-1: #ffffff;
-  --color-gray-2: #f5f5f5;
-  --color-gray-3: #dddddd;
-  --color-gray-4: #a6a6a6;
-  --color-gray-5: #666666;
-  --color-gray-6: #222222;
+  --color-primary-50: oklch(0.969 0.016 293.756);
+  --color-primary-100: oklch(0.943 0.029 294.588);
+  --color-primary-200: oklch(0.894 0.057 293.283);
+  --color-primary-300: oklch(0.811 0.111 293.571);
+  --color-primary-400: oklch(0.702 0.183 293.541);
+  --color-primary-500: oklch(0.606 0.25 292.717);
+  --color-primary-600: oklch(0.541 0.281 293.009);
+  --color-primary-700: oklch(0.491 0.27 292.581);
+  --color-primary-800: oklch(0.432 0.232 292.759);
+  --color-primary-900: oklch(0.38 0.189 293.745);
+  --color-primary-950: oklch(0.283 0.141 291.089);
 
-  --color-primary-1: #f2effd;
-  --color-primary-2: #ede6ff;
-  --color-primary-3: #d7cbf7;
-  --color-primary-4: #b69cf1;
-  --color-primary-5: #986be9;
-  --color-primary-6: #7c35d9;
-  --color-primary-7: #522193;
+  --color-success: oklch(72.3% 0.219 149.579);
 
-  --color-green: #5eb669;
-  --color-light-green: #37f4e9;
-
-  --color-red: #cc0a0a;
-  --color-pale-pink: #f9e2e2;
-
-  --color-yellow: #f6a818;
-  --color-pale-yellow: #fdeece;
+  --color-danger: oklch(63.7% 0.237 25.331);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #11

## 📝작업 내용

> 테일윈드 색상 디자인 토큰

- 패딩이나 갭 같은 토큰도 있긴 한데 피그마 내에서 중구난방으로 적용되어 있어 색상만 적용했습니다.
- 피그마 내 색상 디자인 시스템이 통일되어 있지 않아 primary 색상을 tailwind의 violet 색상을 매핑시켜놨습니다. 그때마다 피그마를 보고 적당히 비슷한 색상을 골라야 할 것 같습니다.
- 회색은 테일윈드의 neutral 색상을 사용해주세요.
- success와 danger 색상 추가했습니다.


### 스크린샷 (선택)

+ 예시 코드
```tsx
function App() {
  return (
    <div className="bg-primary-500 text-success h-screen p-10">template</div>
  );
}
```
<img width="410" height="202" alt="Screenshot 2025-12-09 at 2 51 06 PM" src="https://github.com/user-attachments/assets/06fcba35-472e-4208-a004-e1f9dc89c02b" />



### ✅ 이슈 자동 종료

> 이 PR이 머지될 때 자동으로 이슈를 닫으려면 아래에 작성해주세요.
>
> **Closes #11**