### PR TITLE
Feature: 사이드바 탭 버튼 컴포넌트

### DIFF
--- a/src/components/common/SideBarTapButton.tsx
+++ b/src/components/common/SideBarTapButton.tsx
@@ -11,8 +11,8 @@ function SideBarTapButton({
       className={cn(
         "w-[152px] py-0.5 pl-5 text-left text-base font-bold text-neutral-400 transition-colors ease-in-out focus:outline-none",
         "hover:text-primary-500 hover:bg-primary-100 hover:rounded-sm",
-        "active:order-l-primary-500 active:rounded-none active:border-l-2 active:bg-white active:pl-4",
-        "disabled:pointer-events-none disabled:rounded-sm disabled:bg-neutral-200 disabled:font-normal disabled:text-neutral-400",
+        "active:border-l-primary-500 active:rounded-none active:border-l-2 active:bg-white",
+        "disabled:pointer-events-none disabled:rounded-sm disabled:bg-neutral-200 disabled:font-normal disabled:text-neutral-400 disabled:select-none",
         className
       )}
       {...props}

--- a/src/components/common/SideBarTapButton.tsx
+++ b/src/components/common/SideBarTapButton.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@/lib/utils";
+import type { ComponentProps } from "react";
+
+function SideBarTapButton({
+  className,
+  children,
+  ...props
+}: ComponentProps<"button">) {
+  return (
+    <button
+      className={cn(
+        "w-[152px] py-0.5 pl-5 text-left text-base font-bold text-neutral-400 transition-colors ease-in-out focus:outline-none",
+        "hover:text-primary-500 hover:bg-primary-100 hover:rounded-sm",
+        "active:order-l-primary-500 active:rounded-none active:border-l-2 active:bg-white active:pl-4",
+        "disabled:pointer-events-none disabled:rounded-sm disabled:bg-neutral-200 disabled:font-normal disabled:text-neutral-400",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default SideBarTapButton;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #16

## 📝작업 내용

> 사이드바 탭 버튼 컴포넌트 생성
- hover, active, disabled 상태 css 지정
- 기본 props 등록

## 스크린샷

https://github.com/user-attachments/assets/5ad81827-c985-4896-bf8f-60bfafec2f9b

### ✅ 이슈 자동 종료

> **Closes #16**
