### PR TITLE
feature: Input 컴포넌트 생성

### DIFF
--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/lib/utils";
+import type { ComponentProps } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+const inputVariants = cva(
+  "w-full rounded-md border px-4 py-3 text-sm placeholder:text-neutral-400 focus:outline-none transition-all duration-200 disabled:bg-neutral-100 disabled:text-neutral-400",
+  {
+    variants: {
+      variant: {
+        default: "border-neutral-200 bg-white focus:border-primary-500",
+        danger:
+          "border-danger text-danger focus:border-danger  bg-white placeholder:text-danger",
+        success: "border-success text-success focus:border-success bg-white",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+interface InputProps
+  extends ComponentProps<"input">,
+    VariantProps<typeof inputVariants> {}
+
+export default function Input({ className, variant, ...props }: InputProps) {
+  return (
+    <input className={cn(inputVariants({ variant }), className)} {...props} />
+  );
+}

--- a/src/components/common/Textarea.tsx
+++ b/src/components/common/Textarea.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/lib/utils";
+import type { ComponentProps } from "react";
+
+export default function Textarea({
+  className,
+  ...props
+}: ComponentProps<"textarea">) {
+  return (
+    <textarea
+      className={cn(
+        "min-h-[120px] w-full resize-none rounded-sm border border-neutral-300 px-4 py-3 text-sm transition-all duration-200 placeholder:text-neutral-400",
+        "focus:border-neutral-300 focus:ring-1 focus:ring-neutral-300 focus:outline-none",
+        "disabled:bg-neutral-100 disabled:text-neutral-400",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/common/Textarea.tsx
+++ b/src/components/common/Textarea.tsx
@@ -8,9 +8,8 @@ export default function Textarea({
   return (
     <textarea
       className={cn(
-        "min-h-[120px] w-full resize-none rounded-sm border border-neutral-300 px-4 py-3 text-sm transition-all duration-200 placeholder:text-neutral-400",
-        "focus:border-neutral-300 focus:ring-1 focus:ring-neutral-300 focus:outline-none",
-        "disabled:bg-neutral-100 disabled:text-neutral-400",
+        "min-h-[120px] w-full resize-none rounded-sm border border-neutral-300 bg-neutral-100 px-4 py-3 text-sm transition-all duration-200 placeholder:text-neutral-400",
+        "focus:border-neutral-400 focus:outline-none",
         className
       )}
       {...props}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용

> Input 컴포넌트 생성

- Default 외 5개 input 컴포넌트 작업

### 스크린샷

- 구현완료
<img width="762" height="679" alt="input" src="https://github.com/user-attachments/assets/5945500c-fa54-4f49-8ae4-f6e0d3d39b01" />

- 요청사항
<img width="554" height="539" alt="Group 14214" src="https://github.com/user-attachments/assets/c2b58b9b-225c-4e79-86ac-89678e865d73" />


### ✅ 이슈 자동 종료
