### PR TITLE
Feature: useWindowSize 훅 

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,5 @@
 //hooks
 import useToast from "@/hooks/useToast";
+import useWindowSize from "@/hooks/useWindowSize";
 
-export { useToast };
+export { useToast, useWindowSize };

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+export default function useWindowSize() {
+  const [windowHeight, setWindowHeight] = useState<number>(window.innerHeight);
+  const [windowWidth, setWindowWidth] = useState<number>(window.innerWidth);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowHeight(window.innerHeight);
+      setWindowWidth(window.innerWidth);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    handleResize();
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return { windowHeight, windowWidth };
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #38

## 📝작업 내용

> 현재 윈도우 사이즈를 반환하는 훅 생성

+ 예시 코드

```typescript
import { useWindowSize } from "@/hooks";

export default function Home() {
  const { windowHeight, windowWidth } = useWindowSize();

  console.log(`높이: ${windowHeight}`);
  console.log(`넓이: ${windowWidth}`);

  return <div>Home</div>;
}
```

### 스크린샷 (선택)

https://github.com/user-attachments/assets/9474ea33-5781-4ea0-bba3-a53f8b5c0085


### ✅ 이슈 자동 종료

> 이 PR이 머지될 때 자동으로 이슈를 닫으려면 아래에 작성해주세요.
>
> **Closes #38** 
