### PR TITLE
Feature: useOutsideInteraction 훅

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,5 @@
-//hooks
 import useToast from "@/hooks/useToast";
 import useWindowSize from "@/hooks/useWindowSize";
+import useOutsideInteraction from "@/hooks/useOutsideInteraction";
 
-export { useToast, useWindowSize };
+export { useToast, useWindowSize, useOutsideInteraction };

--- a/src/hooks/useOutsideInteraction.ts
+++ b/src/hooks/useOutsideInteraction.ts
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+
+export interface OutsideInteractionHandler {
+  type: keyof DocumentEventMap;
+  handler: (event?: Event) => void;
+}
+
+function useOutsideInteraction(
+  ref: React.RefObject<HTMLElement | null>,
+  interactions: OutsideInteractionHandler[]
+) {
+  useEffect(() => {
+    const eventHandlers = interactions.map(
+      ({ type, handler: originalHandler }) => {
+        const wrappedHandler = (event: Event) => {
+          const element = ref.current;
+
+          if (!element) return;
+          if (!element.contains(event.target as Node)) originalHandler(event);
+        };
+
+        document.addEventListener(type, wrappedHandler);
+        return { type, wrappedHandler };
+      }
+    );
+
+    return () =>
+      eventHandlers.forEach(({ type, wrappedHandler }) =>
+        document.removeEventListener(type, wrappedHandler)
+      );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}
+
+export default useOutsideInteraction;

--- a/src/hooks/useOutsideInteraction.ts
+++ b/src/hooks/useOutsideInteraction.ts
@@ -1,19 +1,20 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 export interface OutsideInteractionHandler {
   type: keyof DocumentEventMap;
   handler: (event?: Event) => void;
 }
 
-function useOutsideInteraction(
-  ref: React.RefObject<HTMLElement | null>,
+function useOutsideInteraction<T extends HTMLElement>(
   interactions: OutsideInteractionHandler[]
 ) {
+  const targetRef = useRef<T>(null);
+
   useEffect(() => {
     const eventHandlers = interactions.map(
       ({ type, handler: originalHandler }) => {
         const wrappedHandler = (event: Event) => {
-          const element = ref.current;
+          const element = targetRef.current;
 
           if (!element) return;
           if (!element.contains(event.target as Node)) originalHandler(event);
@@ -30,6 +31,8 @@ function useOutsideInteraction(
       );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  return targetRef;
 }
 
 export default useOutsideInteraction;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #43

## 📝작업 내용

> 지정한 HTML 요소 바깥에서 일어나는 이벤트를 감지하여 콜백함수를 실행해주는 훅 생성
- 사용법
1.  useOutsideInteraction 훅을 제네릭 타입을 지정하여 호출합니다.
      - 제네릭 타입은 외부 이벤트를 감지하고자 하는 요소의 DOM 타입으로 지정합니다.
2. 훅 호출 후 반환받은 ref를 외부 이벤트를 감지하고자 하는 요소에 연결합니다.

- 예시 코드
```
import { useState } from "react";
import { useOutsideInteraction } from "@/hooks";

function Test() {
  const [isMenuOpen, setIsMenuOpen] = useState(false);

  const openMenu = () => setIsMenuOpen(true);
  const closeMenu = () => setIsMenuOpen(false);

  const menuRef = useOutsideInteraction<HTMLDivElement>([ // 제네릭 타입 지정하여 호출
    {
      type: "mousedown",
      handler: () => closeMenu(),
    },
  ]);

  return (
    <div className="p-10">
      <button onClick={openMenu} className="border-success border-4">
        Open Menu
      </button>
      {isMenuOpen && (
        <div ref={menuRef} className="border-4 p-10"> // ref 연결
          Menu....
        </div>
      )}
    </div>
  );
}

export default Test;
```

### 스크린샷
https://github.com/user-attachments/assets/c47af8df-86cf-4cf0-a4a5-0ad6c421b26f

### ✅ 이슈 자동 종료

> **Closes #43**
