### PR TITLE
Feature: 드롭다운 컴포넌트

### DIFF
--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -10,6 +10,7 @@ import {
   type SelectedOption,
 } from "@/components/common/dropdown";
 import { useOutsideInteraction } from "@/hooks";
+import { cn } from "@/lib/utils";
 
 interface DropdownProps {
   onChange: (newValue: string) => void;
@@ -17,6 +18,7 @@ interface DropdownProps {
   disabled?: boolean;
   allowCustomInput?: boolean;
   customInputHeight?: number;
+  className?: string;
 }
 
 function Dropdown({
@@ -25,6 +27,7 @@ function Dropdown({
   disabled,
   allowCustomInput = false,
   customInputHeight = 120,
+  className = "",
 }: DropdownProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [selectedOption, setSelectedOption] = useState<SelectedOption>(null);
@@ -62,7 +65,7 @@ function Dropdown({
 
   return (
     <div
-      className="relative flex flex-col gap-0.5"
+      className={cn("relative flex flex-col gap-0.5", className)}
       onKeyDown={handleKeyDown}
       ref={dropdownRef}
     >

--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -9,7 +9,6 @@ import {
   type DropdownOption,
   type SelectedOption,
 } from "@/components/common/dropdown";
-import { cn } from "@/lib/utils";
 import { useOutsideInteraction } from "@/hooks";
 
 interface DropdownProps {
@@ -17,7 +16,7 @@ interface DropdownProps {
   options: DropdownOption[];
   disabled?: boolean;
   allowCustomInput?: boolean;
-  className?: string;
+  customInputHeight?: number;
 }
 
 function Dropdown({
@@ -25,7 +24,7 @@ function Dropdown({
   options,
   disabled,
   allowCustomInput = false,
-  className,
+  customInputHeight = 120,
 }: DropdownProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [selectedOption, setSelectedOption] = useState<SelectedOption>(null);
@@ -63,7 +62,7 @@ function Dropdown({
 
   return (
     <div
-      className={cn("relative flex flex-col gap-0.5", className)}
+      className="relative flex flex-col gap-0.5"
       onKeyDown={handleKeyDown}
       ref={dropdownRef}
     >
@@ -90,6 +89,7 @@ function Dropdown({
           onChange={handleCustomInputValueChange}
           onFocus={handleCustomInputFocus}
           onBlur={handleCustomInputBlur}
+          height={customInputHeight}
         />
       )}
     </div>

--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  DropdownTrigger,
+  DropdownContent,
+  DropdownCustomInput,
+  DEFAULT_PLACEHOLDER,
+  CUSTOM_OPTION,
+  MAX_CUSTOM_INPUT_LENGTH,
+  type DropdownOption,
+  type SelectedOption,
+} from "@/components/common/dropdown";
+import { cn } from "@/lib/utils";
+
+interface DropdownProps {
+  onChange: (newValue: string) => void;
+  options: DropdownOption[];
+  disabled?: boolean;
+  allowCustomInput?: boolean;
+  className?: string;
+}
+
+function Dropdown({
+  onChange,
+  options,
+  disabled,
+  allowCustomInput = false,
+  className,
+}: DropdownProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [selectedOption, setSelectedOption] = useState<SelectedOption>(null);
+  const [customInputValue, setCustomInputValue] = useState("");
+  const [isCustomInputFocused, setIsCustomInputFocused] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const isCustomOptionSelected =
+    allowCustomInput && selectedOption?.label === CUSTOM_OPTION.label;
+  const placeholder = selectedOption?.label ?? DEFAULT_PLACEHOLDER;
+
+  // ------ menu ------
+  const closeMenu = () => setIsMenuOpen(false);
+  const toggleMenu = () => setIsMenuOpen((prev) => !prev);
+  // ------ option ------
+  const handleOptionSelect = (newOption: DropdownOption) => {
+    setSelectedOption(newOption);
+    onChange(newOption.value);
+    closeMenu();
+  };
+  // ------ custom input ------
+  const handleCustomInputValueChange = (newValue: string) => {
+    if (newValue.length > MAX_CUSTOM_INPUT_LENGTH) return;
+    setCustomInputValue(newValue);
+    onChange(newValue);
+  };
+  const handleCustomInputFocus = () => setIsCustomInputFocused(true);
+  const handleCustomInputBlur = () => setIsCustomInputFocused(false);
+  // ------ key ------
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Escape") closeMenu();
+  };
+
+  useEffect(() => {
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (!dropdownRef.current) return;
+      if (!dropdownRef.current.contains(event.target as Node)) closeMenu();
+    };
+
+    document.addEventListener("mousedown", handleOutsideClick);
+
+    return () => document.removeEventListener("mousedown", handleOutsideClick);
+  }, []);
+
+  return (
+    <div
+      className={cn("relative flex flex-col gap-0.5", className)}
+      onKeyDown={handleKeyDown}
+      ref={dropdownRef}
+    >
+      <DropdownTrigger
+        customInputValue={customInputValue}
+        placeholder={placeholder}
+        isMenuOpen={isMenuOpen}
+        isCustomOptionSelected={isCustomOptionSelected}
+        isCustomInputFocused={isCustomInputFocused}
+        disabled={disabled}
+        onClick={toggleMenu}
+        onKeyDown={handleKeyDown}
+      />
+      <DropdownContent
+        isMenuOpen={isMenuOpen}
+        options={options}
+        allowCustomInput={allowCustomInput}
+        selectedOption={selectedOption}
+        onSelectOption={handleOptionSelect}
+      />
+      {allowCustomInput && isCustomOptionSelected && (
+        <DropdownCustomInput
+          value={customInputValue}
+          onChange={handleCustomInputValueChange}
+          onFocus={handleCustomInputFocus}
+          onBlur={handleCustomInputBlur}
+        />
+      )}
+    </div>
+  );
+}
+
+export default Dropdown;

--- a/src/components/common/dropdown/Dropdown.tsx
+++ b/src/components/common/dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import {
   DropdownTrigger,
   DropdownContent,
@@ -10,6 +10,7 @@ import {
   type SelectedOption,
 } from "@/components/common/dropdown";
 import { cn } from "@/lib/utils";
+import { useOutsideInteraction } from "@/hooks";
 
 interface DropdownProps {
   onChange: (newValue: string) => void;
@@ -30,7 +31,6 @@ function Dropdown({
   const [selectedOption, setSelectedOption] = useState<SelectedOption>(null);
   const [customInputValue, setCustomInputValue] = useState("");
   const [isCustomInputFocused, setIsCustomInputFocused] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
   const isCustomOptionSelected =
     allowCustomInput && selectedOption?.label === CUSTOM_OPTION.label;
   const placeholder = selectedOption?.label ?? DEFAULT_PLACEHOLDER;
@@ -57,16 +57,9 @@ function Dropdown({
     if (event.key === "Escape") closeMenu();
   };
 
-  useEffect(() => {
-    const handleOutsideClick = (event: MouseEvent) => {
-      if (!dropdownRef.current) return;
-      if (!dropdownRef.current.contains(event.target as Node)) closeMenu();
-    };
-
-    document.addEventListener("mousedown", handleOutsideClick);
-
-    return () => document.removeEventListener("mousedown", handleOutsideClick);
-  }, []);
+  const dropdownRef = useOutsideInteraction<HTMLDivElement>([
+    { type: "mousedown", handler: () => closeMenu() },
+  ]);
 
   return (
     <div

--- a/src/components/common/dropdown/DropdownContent.tsx
+++ b/src/components/common/dropdown/DropdownContent.tsx
@@ -1,0 +1,57 @@
+import {
+  DropdownItem,
+  CUSTOM_OPTION,
+  type DropdownOption,
+  type SelectedOption,
+} from "@/components/common/dropdown";
+import { cn } from "@/lib/utils";
+
+interface DropdownContentProps {
+  isMenuOpen: boolean;
+  options: DropdownOption[];
+  allowCustomInput?: boolean;
+  selectedOption: SelectedOption;
+  onSelectOption: (newOption: DropdownOption) => void;
+}
+
+function DropdownContent({
+  isMenuOpen,
+  options,
+  allowCustomInput,
+  selectedOption,
+  onSelectOption,
+}: DropdownContentProps) {
+  const displayOptions = allowCustomInput
+    ? [...options, CUSTOM_OPTION]
+    : options;
+  const isScrollable = displayOptions.length > 4;
+
+  if (!isMenuOpen) return null;
+  return (
+    <div
+      className={cn(
+        "absolute top-12 left-0 z-10 w-full rounded-sm border bg-white p-1",
+        { "py-1 pr-0 pl-1": isScrollable }
+      )}
+    >
+      <div
+        className={cn({
+          "dropdown-menu-scroll h-[200px] overflow-y-scroll": isScrollable,
+        })}
+      >
+        <ul>
+          {displayOptions.map((option) => (
+            <DropdownItem
+              key={option.value}
+              option={option}
+              selectedOptionLabel={selectedOption?.label}
+              onSelect={onSelectOption}
+            />
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default DropdownContent;

--- a/src/components/common/dropdown/DropdownCustomInput.tsx
+++ b/src/components/common/dropdown/DropdownCustomInput.tsx
@@ -6,6 +6,7 @@ interface DropdownCustomInputProps {
   onChange: (newValue: string) => void;
   onFocus: () => void;
   onBlur: () => void;
+  height: number;
 }
 
 function DropdownCustomInput({
@@ -13,6 +14,7 @@ function DropdownCustomInput({
   onChange,
   onFocus,
   onBlur,
+  height,
 }: DropdownCustomInputProps) {
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) =>
     onChange(event.target.value);
@@ -20,6 +22,7 @@ function DropdownCustomInput({
   return (
     <div className="flex flex-col gap-1">
       <textarea
+        style={{ height: height }}
         className={cn(
           "scrollbar-none resize-none rounded-sm border border-neutral-300 px-4 py-3 text-sm transition-colors ease-in-out",
           "focus:border-black focus:outline-none",

--- a/src/components/common/dropdown/DropdownCustomInput.tsx
+++ b/src/components/common/dropdown/DropdownCustomInput.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib/utils";
+import { MAX_CUSTOM_INPUT_LENGTH } from "@/components/common/dropdown";
+
+interface DropdownCustomInputProps {
+  value: string;
+  onChange: (newValue: string) => void;
+  onFocus: () => void;
+  onBlur: () => void;
+}
+
+function DropdownCustomInput({
+  value,
+  onChange,
+  onFocus,
+  onBlur,
+}: DropdownCustomInputProps) {
+  const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) =>
+    onChange(event.target.value);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <textarea
+        className={cn(
+          "scrollbar-none resize-none rounded-sm border border-neutral-300 px-4 py-3 text-sm transition-colors ease-in-out",
+          "focus:border-black focus:outline-none",
+          "placeholder:text-[14px] placeholder:text-neutral-300"
+        )}
+        placeholder="탈퇴 사유를 입력해주세요."
+        value={value}
+        onChange={handleChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+      ></textarea>
+      <span
+        className={cn("self-end text-xs", {
+          "text-neutral-300": value.length === 0,
+          "text-neutral-500": value.length > 0,
+        })}
+      >{`${value.length}/${MAX_CUSTOM_INPUT_LENGTH}`}</span>
+    </div>
+  );
+}
+
+export default DropdownCustomInput;

--- a/src/components/common/dropdown/DropdownItem.tsx
+++ b/src/components/common/dropdown/DropdownItem.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/lib/utils";
+import { CheckIcon } from "lucide-react";
+import { type DropdownOption } from "@/components/common/dropdown";
+
+interface DropdownItemProps {
+  option: DropdownOption;
+  selectedOptionLabel: string | undefined;
+  onSelect: (newOption: DropdownOption) => void;
+}
+
+function DropdownItem({
+  option,
+  selectedOptionLabel,
+  onSelect,
+}: DropdownItemProps) {
+  const isSelected = selectedOptionLabel === option.label;
+
+  return (
+    <li
+      className={cn(
+        "flex h-12 items-center justify-between rounded-sm px-3 py-2.5 text-[14px] transition-colors ease-in-out",
+        "hover:bg-primary-100",
+        { "text-primary-500 font-semibold": isSelected }
+      )}
+      onClick={() => onSelect(option)}
+    >
+      {option.label}
+      {isSelected && <CheckIcon size={16} strokeWidth={2.5} />}
+    </li>
+  );
+}
+
+export default DropdownItem;

--- a/src/components/common/dropdown/DropdownTrigger.tsx
+++ b/src/components/common/dropdown/DropdownTrigger.tsx
@@ -1,0 +1,51 @@
+import { cn } from "@/lib/utils";
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+
+interface DropdownTriggerProps {
+  customInputValue: string;
+  placeholder: string;
+  isMenuOpen: boolean;
+  isCustomOptionSelected: boolean;
+  isCustomInputFocused: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+  onKeyDown: (event: React.KeyboardEvent) => void;
+}
+
+function DropdownTrigger({
+  customInputValue,
+  placeholder,
+  isMenuOpen,
+  isCustomOptionSelected,
+  isCustomInputFocused,
+  disabled,
+  onClick,
+  onKeyDown,
+}: DropdownTriggerProps) {
+  return (
+    <button
+      className={cn(
+        "mb-1 flex items-center justify-between rounded-sm border border-neutral-300 px-4 py-2.5 text-[14px] text-neutral-300 transition-colors ease-in-out",
+        "hover:bg-neutral-50 hover:text-black",
+        "focus:text-black focus:outline-none",
+        "disabled:pointer-events-none disabled:bg-neutral-100 disabled:text-neutral-300 disabled:select-none",
+        {
+          "border-black text-black": isMenuOpen || isCustomOptionSelected,
+          "border-neutral-300": customInputValue && !isCustomInputFocused,
+        }
+      )}
+      disabled={disabled}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+    >
+      <span>{placeholder}</span>
+      {isMenuOpen || isCustomOptionSelected ? (
+        <ChevronUpIcon size={20} />
+      ) : (
+        <ChevronDownIcon size={20} />
+      )}
+    </button>
+  );
+}
+
+export default DropdownTrigger;

--- a/src/components/common/dropdown/constants.ts
+++ b/src/components/common/dropdown/constants.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_PLACEHOLDER = "해당되는 항목을 선택해 주세요.";
+
+export const CUSTOM_OPTION = {
+  value: "__custom__",
+  label: "기타(직접입력)",
+} as const;
+
+export const MAX_CUSTOM_INPUT_LENGTH = 100;

--- a/src/components/common/dropdown/index.ts
+++ b/src/components/common/dropdown/index.ts
@@ -1,6 +1,28 @@
+import Dropdown from "@/components/common/dropdown/Dropdown";
+import DropdownTrigger from "@/components/common/dropdown/DropdownTrigger";
+import DropdownContent from "@/components/common/dropdown/DropdownContent";
+import DropdownItem from "@/components/common/dropdown/DropdownItem";
+import DropdownCustomInput from "@/components/common/dropdown/DropdownCustomInput";
+
+import {
+  DEFAULT_PLACEHOLDER,
+  CUSTOM_OPTION,
+  MAX_CUSTOM_INPUT_LENGTH,
+} from "@/components/common/dropdown/constants";
+
 import type {
   DropdownOption,
   SelectedOption,
 } from "@/components/common/dropdown/types";
 
+export {
+  Dropdown,
+  DropdownTrigger,
+  DropdownContent,
+  DropdownItem,
+  DropdownCustomInput,
+  DEFAULT_PLACEHOLDER,
+  CUSTOM_OPTION,
+  MAX_CUSTOM_INPUT_LENGTH,
+};
 export type { DropdownOption, SelectedOption };

--- a/src/components/common/dropdown/index.ts
+++ b/src/components/common/dropdown/index.ts
@@ -1,0 +1,6 @@
+import type {
+  DropdownOption,
+  SelectedOption,
+} from "@/components/common/dropdown/types";
+
+export type { DropdownOption, SelectedOption };

--- a/src/components/common/dropdown/types.ts
+++ b/src/components/common/dropdown/types.ts
@@ -1,0 +1,6 @@
+export interface DropdownOption {
+  label: string;
+  value: string;
+}
+
+export type SelectedOption = DropdownOption | null;

--- a/src/index.css
+++ b/src/index.css
@@ -62,3 +62,31 @@ body {
     }
   }
 }
+
+@layer utilities {
+  .scrollbar-none {
+    scrollbar-width: none;
+  }
+}
+
+@layer components {
+  .dropdown-menu-scroll {
+    &::-webkit-scrollbar {
+      width: 12px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+      margin-top: 2px;
+      margin-bottom: 138px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      @apply bg-neutral-300;
+
+      border: 5px solid transparent;
+      border-radius: 999px;
+      background-clip: padding-box;
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #21

## 📝작업 내용

> 드롭다운 컴포넌트
- 드롭다운 옵션 타입 정의
- 드롭다운 컴포넌트 생성

- 구조
  - 크게 DropdownTrigger, DropdownContent, DropdownCustomInput 3개 부분으로 구성되어 있습니다.
  - DropdownContent는 DropdownItem을 리스트 형식으로 랜더링합니다.
<img width="657" height="493" alt="image" src="https://github.com/user-attachments/assets/4b28dd22-dc7a-40b9-bd5a-41bce636ff4c" />

- 사용법
  - 필수 props
    - onChange: 드롭다운과 연결된 state를 변경시킬 수 있는 setter 함수
    - options: 드롭다운에 표시될 옵션 정보가 담긴 배열 (개별 옵션은 { label: string, value: string } 형식)
  - 선택 props
    - disabled: 드롭다운 비활성화 여부 (true / false)
    - allowCustomInput: 커스텀 옵션 허용 여부 (true / false)
      - true인 경우 드롭다운에 기타(직접입력) 옵션이 가장 마지막 옵션으로 제공됩니다.
      - 기본값은 false입니다.
    - customInputHeight: 커스텀 옵션 입력창 높이값
      - number 형식의 값을 전달해야하며 높이는 px단위로 설정됩니다.
      - 기본값은 120입니다.
    - className: Tailwind CSS 클래스 문자열
      - Dropdown 컴포넌트의 최상위 부모 요소에 적용됩니다.
      - 기본값은 빈 문자열입니다.

- 예시 코드
```typescript
import { Dropdown } from "@/components/common/dropdown";
import { useState } from "react";

function Test() {
  const [value, setValue] = useState("");
  const dropdownOptions = [
    { label: "Select 1", value: "select 1" },
    { label: "Select 2", value: "select 2" },
    { label: "Select 3", value: "select 3" },
    { label: "Select 4", value: "select 4" },
  ];

  const handleValueChange = (newValue: string) => setValue(newValue);

  return (
    <div>
      <Dropdown
        onChange={handleValueChange}
        options={dropdownOptions}
        allowCustomInput
        disabled
        customInputHeight={200}
        className="w-60"
      />
    </div>
  );
}

export default Test;
```

### 스크린샷

https://github.com/user-attachments/assets/cef4b9b6-bd8e-4a47-b05a-604187c7a3a8

### ✅ 이슈 자동 종료

> **Closes #21**
