### PR TITLE
Feature: 모달 컴포넌트

### DIFF
--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -1,0 +1,37 @@
+import ModalOverlay from "@/components/common/modal/ModalOverlay";
+import type { ModalContent, ModalTrigger } from "@/components/common/modal";
+import { ModalContext } from "@/hooks";
+import { useState, type ReactElement } from "react";
+
+type ModalChildren =
+  | ReactElement<typeof ModalTrigger>
+  | ReactElement<typeof ModalContent>;
+
+interface ModalProps {
+  children: ModalChildren | ModalChildren[];
+  isOverlay?: boolean;
+}
+
+export default function Modal({ children, isOverlay = true }: ModalProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = () => setIsOpen(true);
+
+  const close = () => setIsOpen(false);
+
+  const toggle = () => setIsOpen((prev) => !prev);
+
+  return (
+    <ModalContext.Provider
+      value={{
+        isOpen,
+        open,
+        close,
+        toggle,
+      }}
+    >
+      {isOverlay ? <ModalOverlay /> : null}
+      <div>{children}</div>
+    </ModalContext.Provider>
+  );
+}

--- a/src/components/common/modal/ModalClose.tsx
+++ b/src/components/common/modal/ModalClose.tsx
@@ -1,0 +1,24 @@
+import { useModalContext } from "@/hooks";
+import { cn } from "@/lib/utils";
+import type { ComponentProps, ReactNode } from "react";
+
+interface ModalCloseProps extends ComponentProps<"div"> {
+  children: ReactNode;
+}
+
+export default function ModalClose({
+  children,
+  className,
+  ...props
+}: ModalCloseProps) {
+  const { close } = useModalContext();
+  return (
+    <div
+      onClick={close}
+      {...props}
+      className={cn("hover:cursor-pointer", className)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/modal/ModalContent.tsx
+++ b/src/components/common/modal/ModalContent.tsx
@@ -1,0 +1,59 @@
+import { useModalContext } from "@/hooks";
+import { cn } from "@/lib/utils";
+import {
+  useEffect,
+  useState,
+  type ComponentProps,
+  type ReactNode,
+} from "react";
+
+const MODAL_ANIMATION_TIME_MS = 120;
+
+interface ModalContentProps extends ComponentProps<"div"> {
+  children: ReactNode;
+  isPositionCenter?: boolean;
+}
+
+export default function ModalContent({
+  children,
+  className,
+  isPositionCenter = true,
+  ...props
+}: ModalContentProps) {
+  const { isOpen } = useModalContext();
+  const [show, setShow] = useState(false);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setShow(true);
+      const timer = setTimeout(
+        () => setIsAnimating(true),
+        MODAL_ANIMATION_TIME_MS
+      );
+      return () => clearTimeout(timer);
+    }
+    setIsAnimating(false);
+    const timer = setTimeout(() => setShow(false), MODAL_ANIMATION_TIME_MS);
+    return () => clearTimeout(timer);
+  }, [isOpen]);
+
+  if (!show) return null;
+
+  return (
+    <div
+      className={cn(
+        "fixed z-50 flex min-w-64 transform flex-col rounded-xl bg-white transition-all",
+        isPositionCenter
+          ? "top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
+          : "",
+        `duration-[${MODAL_ANIMATION_TIME_MS}]`,
+        isAnimating ? "scale-100 opacity-100" : "scale-95 opacity-0",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/modal/ModalContent.tsx
+++ b/src/components/common/modal/ModalContent.tsx
@@ -1,6 +1,7 @@
 import { MODAL_ANIMATION_TIME_MS } from "@/constants";
 import { useModalContext } from "@/hooks";
 import { cn } from "@/lib/utils";
+import { XIcon } from "lucide-react";
 import {
   useEffect,
   useState,
@@ -11,15 +12,17 @@ import {
 interface ModalContentProps extends ComponentProps<"div"> {
   children: ReactNode;
   isPositionCenter?: boolean;
+  hasCloseIcon?: boolean;
 }
 
 export default function ModalContent({
   children,
   className,
   isPositionCenter = true,
+  hasCloseIcon = true,
   ...props
 }: ModalContentProps) {
-  const { isOpen } = useModalContext();
+  const { isOpen, close } = useModalContext();
   const [show, setShow] = useState(false);
   const [isAnimating, setIsAnimating] = useState(false);
 
@@ -52,6 +55,17 @@ export default function ModalContent({
       )}
       {...props}
     >
+      {hasCloseIcon && (
+        <div className="flex items-center justify-end">
+          <button
+            onClick={() => {
+              close();
+            }}
+          >
+            <XIcon />
+          </button>
+        </div>
+      )}
       {children}
     </div>
   );

--- a/src/components/common/modal/ModalContent.tsx
+++ b/src/components/common/modal/ModalContent.tsx
@@ -1,3 +1,4 @@
+import { MODAL_ANIMATION_TIME_MS } from "@/constants";
 import { useModalContext } from "@/hooks";
 import { cn } from "@/lib/utils";
 import {
@@ -6,8 +7,6 @@ import {
   type ComponentProps,
   type ReactNode,
 } from "react";
-
-const MODAL_ANIMATION_TIME_MS = 120;
 
 interface ModalContentProps extends ComponentProps<"div"> {
   children: ReactNode;

--- a/src/components/common/modal/ModalContent.tsx
+++ b/src/components/common/modal/ModalContent.tsx
@@ -45,7 +45,7 @@ export default function ModalContent({
   return (
     <div
       className={cn(
-        "fixed z-50 flex min-w-64 transform flex-col rounded-xl bg-white transition-all",
+        "fixed z-50 flex min-w-64 transform flex-col rounded-xl bg-white p-6 transition-all",
         isPositionCenter
           ? "top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
           : "",
@@ -56,13 +56,13 @@ export default function ModalContent({
       {...props}
     >
       {hasCloseIcon && (
-        <div className="flex items-center justify-end">
+        <div className="flex items-center justify-end p-1.5">
           <button
             onClick={() => {
               close();
             }}
           >
-            <XIcon />
+            <XIcon className="size-5 text-neutral-400" />
           </button>
         </div>
       )}

--- a/src/components/common/modal/ModalOverlay.tsx
+++ b/src/components/common/modal/ModalOverlay.tsx
@@ -1,0 +1,58 @@
+import { MODAL_ANIMATION_TIME_MS } from "@/constants";
+import { useModalContext } from "@/hooks";
+import { cn } from "@/lib/utils";
+import { useEffect, useState } from "react";
+
+export default function ModalOverlay() {
+  const { isOpen, close } = useModalContext();
+  const [show, setShow] = useState(false);
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setShow(true);
+      const timer = setTimeout(
+        () => setIsAnimating(true),
+        MODAL_ANIMATION_TIME_MS
+      ); // For animation
+      return () => clearTimeout(timer);
+    }
+    setIsAnimating(false);
+    const timer = setTimeout(() => setShow(false), MODAL_ANIMATION_TIME_MS); // Delay unmount for animation
+    return () => clearTimeout(timer);
+  }, [isOpen]);
+
+  // 스크롤 방지
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  // ESC 키 닫기
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, close]);
+
+  if (!show) return null;
+  return (
+    <div
+      className={cn(
+        "fixed inset-0 z-40 bg-black/50 transition-opacity",
+        `duration-[${MODAL_ANIMATION_TIME_MS}]`,
+        isAnimating ? "opacity-100" : "opacity-0"
+      )}
+      onClick={close}
+    />
+  );
+}

--- a/src/components/common/modal/ModalTrigger.tsx
+++ b/src/components/common/modal/ModalTrigger.tsx
@@ -1,0 +1,24 @@
+import { useModalContext } from "@/hooks";
+import { cn } from "@/lib/utils";
+import type { ComponentProps, ReactNode } from "react";
+
+interface ModalTriggerProps extends ComponentProps<"div"> {
+  children: ReactNode;
+}
+
+export default function ModalTrigger({
+  children,
+  className,
+  ...props
+}: ModalTriggerProps) {
+  const { toggle } = useModalContext();
+  return (
+    <div
+      onClick={toggle}
+      {...props}
+      className={cn("hover:cursor-pointer", className)}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/modal/index.ts
+++ b/src/components/common/modal/index.ts
@@ -1,3 +1,4 @@
 import ModalContent from "@/components/common/modal/ModalContent";
+import ModalTrigger from "@/components/common/modal/ModalTrigger";
 
-export { ModalContent };
+export { ModalContent, ModalTrigger };

--- a/src/components/common/modal/index.ts
+++ b/src/components/common/modal/index.ts
@@ -2,5 +2,6 @@ import ModalContent from "@/components/common/modal/ModalContent";
 import ModalTrigger from "@/components/common/modal/ModalTrigger";
 import ModalClose from "@/components/common/modal/ModalClose";
 import ModalOverlay from "@/components/common/modal/ModalOverlay";
+import Modal from "@/components/common/modal/Modal";
 
-export { ModalContent, ModalTrigger, ModalClose, ModalOverlay };
+export { ModalContent, ModalTrigger, ModalClose, ModalOverlay, Modal };

--- a/src/components/common/modal/index.ts
+++ b/src/components/common/modal/index.ts
@@ -1,5 +1,6 @@
 import ModalContent from "@/components/common/modal/ModalContent";
 import ModalTrigger from "@/components/common/modal/ModalTrigger";
 import ModalClose from "@/components/common/modal/ModalClose";
+import ModalOverlay from "@/components/common/modal/ModalOverlay";
 
-export { ModalContent, ModalTrigger, ModalClose };
+export { ModalContent, ModalTrigger, ModalClose, ModalOverlay };

--- a/src/components/common/modal/index.ts
+++ b/src/components/common/modal/index.ts
@@ -1,4 +1,5 @@
 import ModalContent from "@/components/common/modal/ModalContent";
 import ModalTrigger from "@/components/common/modal/ModalTrigger";
+import ModalClose from "@/components/common/modal/ModalClose";
 
-export { ModalContent, ModalTrigger };
+export { ModalContent, ModalTrigger, ModalClose };

--- a/src/components/common/modal/index.ts
+++ b/src/components/common/modal/index.ts
@@ -1,0 +1,3 @@
+import ModalContent from "@/components/common/modal/ModalContent";
+
+export { ModalContent };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
 import { CAMP_LIST, INFO_LIST, SNS_LIST } from "@/constants/footer-constants";
+import { MODAL_ANIMATION_TIME_MS } from "@/constants/modal-constants";
 
-export { CAMP_LIST, INFO_LIST, SNS_LIST };
+export { CAMP_LIST, INFO_LIST, SNS_LIST, MODAL_ANIMATION_TIME_MS };

--- a/src/constants/modal-constants.ts
+++ b/src/constants/modal-constants.ts
@@ -1,0 +1,1 @@
+export const MODAL_ANIMATION_TIME_MS = 120;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,12 @@
 import useToast from "@/hooks/useToast";
 import useWindowSize from "@/hooks/useWindowSize";
 import useOutsideInteraction from "@/hooks/useOutsideInteraction";
+import useModalContext, { ModalContext } from "@/hooks/useModalContext";
 
-export { useToast, useWindowSize, useOutsideInteraction };
+export {
+  useToast,
+  useWindowSize,
+  useOutsideInteraction,
+  useModalContext,
+  ModalContext,
+};

--- a/src/hooks/useModalContext.ts
+++ b/src/hooks/useModalContext.ts
@@ -4,7 +4,7 @@ import type { ModalContextType } from "@/types";
 export const ModalContext = createContext<ModalContextType | null>(null);
 
 export default function useModalContext() {
-  const ctx = useContext(ModalContext);
-  if (!ctx) throw new Error("Modal components must be used within <Modal>");
-  return ctx;
+  const context = useContext(ModalContext);
+  if (!context) throw new Error("Modal components must be used within <Modal>");
+  return context;
 }

--- a/src/hooks/useModalContext.ts
+++ b/src/hooks/useModalContext.ts
@@ -1,0 +1,10 @@
+import { useContext, createContext } from "react";
+import type { ModalContextType } from "@/types";
+
+export const ModalContext = createContext<ModalContextType | null>(null);
+
+export default function useModalContext() {
+  const ctx = useContext(ModalContext);
+  if (!ctx) throw new Error("Modal components must be used within <Modal>");
+  return ctx;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 import type { FooterLinkItem, FooterSnsLinkItem } from "@/types/footer-types";
+import type { ModalContextType } from "@/types/modal-context-type";
 
-export type { FooterLinkItem, FooterSnsLinkItem };
+export type { FooterLinkItem, FooterSnsLinkItem, ModalContextType };

--- a/src/types/modal-context-type.ts
+++ b/src/types/modal-context-type.ts
@@ -1,0 +1,6 @@
+export interface ModalContextType {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #56

## 📝작업 내용

> 모달 컴포넌트 구현

+ 모달 관련 컴포넌트들 생성
  + Modal: wrapper 컴포넌트
  + ModalTrigger: 해당 컴포넌트 클릭 시 모달 생성
  + ModalContent: 모달 안에 들어가는 내용
  + ModalOverlay: 모달 뒤에 검정 화면
  + ModalClose: 해당 컴포넌트 클릭 시 모달 닫기

+ 구현사항
  + 각각의 모달이 독립적인 컨텍스트를 가지는 형태입니다.
  + esc 및 모달 바깥쪽 클릭으로도 컴포넌트가 닫힙니다.
  + ModalContent의 hasCloseIcon으로 X 아이콘을 사용할지 말지 선택할 수 있습니다.

+ 참고사항
  + 모달 자체가 사용해야하는 컴포넌트가 많아 자체적으로 배럴파일을 사용했습니다.

+ 예시코드
```jsx
      {/* X 아이콘 있음 */}
      <Modal>
        <ModalTrigger>
          <Button>모달열기</Button>
        </ModalTrigger>
        <ModalContent className="gap-5">
          <span className="text-4xl font-bold">Don't look back in anger</span>
          <span className="w-2xs">
            And so Sally can wait She knows it's too late As we're walking on by
            Her soul slides away But don't look back in anger I heard you say
          </span>
          <ModalClose>
            <Button>닫기</Button>
          </ModalClose>
        </ModalContent>
      </Modal>

      {/* X 아이콘 없음 */}
      <Modal>
        <ModalTrigger>
          <Button>모달열기</Button>
        </ModalTrigger>
        <ModalContent className="gap-5" hasCloseIcon={false}>
          <span className="text-4xl font-bold">X 없음</span>
          <span className="w-2xs">
            And so Sally can wait She knows it's too late As we're walking on by
            Her soul slides away But don't look back in anger I heard you say
          </span>
          <ModalClose>
            <Button>닫기</Button>
          </ModalClose>
        </ModalContent>
      </Modal>
```

### 스크린샷 (선택)

https://github.com/user-attachments/assets/b7360a68-d9da-4daf-91fa-da60a3f2a4ba


## 💬리뷰 요구사항(선택)

> 사용법이 헷갈리면 말씀해주세요.

### ✅ 이슈 자동 종료

> 이 PR이 머지될 때 자동으로 이슈를 닫으려면 아래에 작성해주세요.
>
> **Closes #56** 
