### PR TITLE
Fix: 탭 버튼 클릭 시 페이지 이동 가능하도록 수정

### DIFF
--- a/src/components/common/SideBarTapButton.tsx
+++ b/src/components/common/SideBarTapButton.tsx
@@ -1,24 +1,43 @@
 import { cn } from "@/lib";
-import type { ComponentProps } from "react";
+import { Link } from "react-router";
+
+interface SideBarTapButtonProps {
+  to: string;
+  isActive?: boolean;
+  disabled?: boolean;
+  children: React.ReactNode;
+}
 
 function SideBarTapButton({
-  className,
+  to,
+  isActive = false,
+  disabled = false,
   children,
-  ...props
-}: ComponentProps<"button">) {
+}: SideBarTapButtonProps) {
   return (
-    <button
-      className={cn(
-        "w-[152px] py-0.5 pl-5 text-left text-base font-bold text-neutral-400 transition-colors ease-in-out focus:outline-none",
-        "hover:text-primary-500 hover:bg-primary-100 hover:rounded-sm",
-        "active:border-l-primary-500 active:rounded-none active:border-l-2 active:bg-white",
-        "disabled:pointer-events-none disabled:rounded-sm disabled:bg-neutral-200 disabled:font-normal disabled:text-neutral-400 disabled:select-none",
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </button>
+    <div className="relative">
+      <div
+        className={cn(
+          "pointer-events-none absolute top-0 left-0 h-full w-0.5 bg-transparent select-none",
+          { "bg-primary-500": isActive }
+        )}
+      ></div>
+      <Link
+        to={to}
+        className={cn(
+          "block w-full py-1 pl-5 text-left font-semibold text-neutral-400 transition-colors ease-in-out focus:outline-none",
+          "hover:text-primary-500 hover:bg-primary-100 hover:rounded-sm",
+          {
+            "text-primary-500": isActive,
+            "pointer-events-none rounded-sm bg-neutral-200 font-normal text-neutral-400 select-none":
+              disabled,
+          }
+        )}
+        tabIndex={disabled ? -1 : 0}
+      >
+        {children}
+      </Link>
+    </div>
   );
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #60

## 📝작업 내용

> SideBarTapButton 컴포넌트 수정
- button 태그를 React Router의 Link 태그로 변경
- active 상태를 props로 조정할 수 있도록 변경

### 예시 코드

```typescript
import { SideBarTapButton } from "@/components/common";
import { useLocation } from "react-router";

function SideMenu() {
  const { pathname } = useLocation();

  return (
    <div className="w-50">
      <SideBarTapButton to="/exam" isActive={pathname.startsWith("/exam")}>
        쪽지 시험
      </SideBarTapButton>
      <SideBarTapButton to="/info" isActive={pathname.startsWith("/info")}>
        내 정보
      </SideBarTapButton>
      <SideBarTapButton
        to="/password"
        isActive={pathname.startsWith("/password")}
        disabled
      >
        비밀번호 변경
      </SideBarTapButton>
    </div>
  );
}

```


### 스크린샷

https://github.com/user-attachments/assets/18ee4956-8294-42a0-b54d-fa615d5bfc5c

## ✅ 이슈 자동 종료

> **Closes #60**
