### PR TITLE
Feature: LinkButton 컴포넌트 생성

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,31 +1,6 @@
-import { cn } from "@/lib";
+import { buttonVariants, cn } from "@/lib";
 import type { ComponentProps } from "react";
-import { cva, type VariantProps } from "class-variance-authority";
-
-const buttonVariants = cva(
-  "text-base rounded px-7 py-4 focus:outline-none transition-colors ease-in-out",
-  {
-    variants: {
-      variant: {
-        fill: cn(
-          "text-white bg-primary-500",
-          "hover:bg-primary-600",
-          "active:bg-primary-700",
-          "disabled:text-neutral-400 disabled:bg-neutral-200"
-        ),
-        outline: cn(
-          "text-primary-700 bg-primary-200 border border-primary-500",
-          "hover:bg-primary-300 hover:border-primary-600",
-          "active:bg-primary-400 active:border-primary-700 active:text-primary-800",
-          "disabled:text-neutral-700 disabled:bg-neutral-200 disabled:border-neutral-400"
-        ),
-      },
-    },
-    defaultVariants: {
-      variant: "fill",
-    },
-  }
-);
+import { type VariantProps } from "class-variance-authority";
 
 interface ButtonProps
   extends ComponentProps<"button">,

--- a/src/components/common/LinkButton.tsx
+++ b/src/components/common/LinkButton.tsx
@@ -1,0 +1,21 @@
+import { cn, buttonVariants } from "@/lib";
+import type { VariantProps } from "class-variance-authority";
+import type { ComponentProps } from "react";
+import { Link } from "react-router";
+
+interface LinkButtonProps
+  extends ComponentProps<typeof Link>,
+    VariantProps<typeof buttonVariants> {}
+
+export default function LinkButton({
+  className,
+  children,
+  variant,
+  ...props
+}: LinkButtonProps) {
+  return (
+    <Link className={cn(buttonVariants({ variant }), className)} {...props}>
+      {children}
+    </Link>
+  );
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -5,6 +5,7 @@ import LoadingUi from "@/components/common/LoadingUi";
 import Password from "@/components/common/Password";
 import SideBarTapButton from "@/components/common/SideBarTapButton";
 import Textarea from "@/components/common/Textarea";
+import LinkButton from "@/components/common/LinkButton";
 
 export {
   Dropdown,
@@ -14,4 +15,5 @@ export {
   Password,
   SideBarTapButton,
   Textarea,
+  LinkButton,
 };

--- a/src/lib/buttonVariant.ts
+++ b/src/lib/buttonVariant.ts
@@ -1,0 +1,27 @@
+import { cn } from "@/lib/utils";
+import { cva } from "class-variance-authority";
+
+export const buttonVariants = cva(
+  "text-base rounded px-7 py-4 focus:outline-none transition-colors ease-in-out",
+  {
+    variants: {
+      variant: {
+        fill: cn(
+          "text-white bg-primary-500",
+          "hover:bg-primary-600",
+          "active:bg-primary-700",
+          "disabled:text-neutral-400 disabled:bg-neutral-200"
+        ),
+        outline: cn(
+          "text-primary-700 bg-primary-200 border border-primary-500",
+          "hover:bg-primary-300 hover:border-primary-600",
+          "active:bg-primary-400 active:border-primary-700 active:text-primary-800",
+          "disabled:text-neutral-700 disabled:bg-neutral-200 disabled:border-neutral-400"
+        ),
+      },
+    },
+    defaultVariants: {
+      variant: "fill",
+    },
+  }
+);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,5 +1,6 @@
 import { inputContainerVariants } from "@/lib/inputContainerVariant";
 import { cn } from "@/lib/utils";
 import api from "@/lib/axios";
+import { buttonVariants } from "@/lib/buttonVariant";
 
-export { inputContainerVariants, cn, api };
+export { inputContainerVariants, cn, api, buttonVariants };


### PR DESCRIPTION
## #️⃣연관된 이슈

> #70

## 📝작업 내용

> 기존 Button 컴포넌트와 같은 디자인을 가지는 LinkButton 컴포넌트 생성

+ 예시 코드

```typescript
        <div className="flex flex-col items-center gap-5">
          <LinkButton to="/">홈</LinkButton>
          <LinkButton to="/community" variant={"outline"}>
            시험
          </LinkButton>
        </div>
```

p.s. 링크 태그 안에 버튼을 넣으면 좋지 않다는 것을 이번에 알았네요... 좋은 정보 감사합니다 지혜님.

### 스크린샷 (선택)


https://github.com/user-attachments/assets/1e3d81c9-cae6-46a1-aa7c-66563844e42b



### ✅ 이슈 자동 종료

> 이 PR이 머지될 때 자동으로 이슈를 닫으려면 아래에 작성해주세요.
>
> **Closes #70** 
