### PR TITLE
Refactor: SideBarTabButton에 제네릭 적용

### DIFF
--- a/src/components/common/SideBarTapButton.tsx
+++ b/src/components/common/SideBarTapButton.tsx
@@ -1,19 +1,22 @@
 import { cn } from "@/lib";
-import { Link } from "react-router";
+import type { ComponentProps, ElementType } from "react";
 
-interface SideBarTapButtonProps {
-  to: string;
+type SideBarTapButtonProps<T extends ElementType = "button"> = {
+  as?: T;
   isActive?: boolean;
   disabled?: boolean;
   children: React.ReactNode;
-}
+} & ComponentProps<T>;
 
-function SideBarTapButton({
-  to,
+function SideBarTapButton<T extends ElementType = "button">({
+  as,
   isActive = false,
   disabled = false,
   children,
-}: SideBarTapButtonProps) {
+  ...props
+}: SideBarTapButtonProps<T>) {
+  const Component = as ?? "button";
+
   return (
     <div className="relative">
       <div
@@ -22,8 +25,7 @@ function SideBarTapButton({
           { "bg-primary-500": isActive }
         )}
       ></div>
-      <Link
-        to={to}
+      <Component
         className={cn(
           "block w-full py-1 pl-5 text-left font-semibold text-neutral-400 transition-colors ease-in-out focus:outline-none",
           "hover:text-primary-500 hover:bg-primary-100 hover:rounded-sm",
@@ -34,9 +36,10 @@ function SideBarTapButton({
           }
         )}
         tabIndex={disabled ? -1 : 0}
+        {...props}
       >
         {children}
-      </Link>
+      </Component>
     </div>
   );
 }

--- a/src/components/header/UserMenu.tsx
+++ b/src/components/header/UserMenu.tsx
@@ -1,42 +1,11 @@
 import { useState } from "react";
-import type { ReactNode } from "react";
 import { Link } from "react-router";
 import { UserIcon } from "@/assets/icons/interface-icons/";
-
-interface DropdownItemProps {
-  children: ReactNode;
-  to?: string;
-  onClick?: () => void;
-  className?: string;
-}
+import { SideBarTapButton } from "@/components/common";
 
 interface UserMenuProps {
   onLogout: () => void;
 }
-
-const DropdownItem = ({
-  onClick,
-  to,
-  children,
-  className = "",
-}: DropdownItemProps) => {
-  const baseClass =
-    "block w-full px-2 py-2.5 text-left text-sm text-gray-700 hover:bg-purple-100 hover:text-violet-600 transition-colors";
-
-  if (to) {
-    return (
-      <Link to={to} className={`${baseClass} ${className}`}>
-        {children}
-      </Link>
-    );
-  }
-
-  return (
-    <button onClick={onClick} className={`${baseClass} ${className}`}>
-      {children}
-    </button>
-  );
-};
 
 export default function UserMenu({ onLogout }: UserMenuProps) {
   const [showUserMenu, setShowUserMenu] = useState(false);
@@ -66,12 +35,16 @@ export default function UserMenu({ onLogout }: UserMenuProps) {
           <hr className="my-2 border-gray-200" />
 
           {!isStudent && (
-            <DropdownItem onClick={() => setIsStudent(true)}>
+            <SideBarTapButton as="button" onClick={() => setIsStudent(true)}>
               수강생 등록(임시)
-            </DropdownItem>
+            </SideBarTapButton>
           )}
-          <DropdownItem to="/my-page">마이페이지</DropdownItem>
-          <DropdownItem onClick={onLogout}>로그아웃(임시)</DropdownItem>
+          <SideBarTapButton as={Link} to="/my-page">
+            마이페이지
+          </SideBarTapButton>
+          <SideBarTapButton as="button" onClick={onLogout}>
+            로그아웃(임시)
+          </SideBarTapButton>
         </div>
       )}
     </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #75
## 📝작업 내용

> SideBarTabButton에 제네릭 적용

- as prop에 넣고 싶은 사용하고자하는 엘레멘트나 컴포넌트 사용하면 됩니다.

### 스크린샷 (선택)


https://github.com/user-attachments/assets/4d601cb6-6c43-49c6-a0ea-0a221f2702bb




## 💬리뷰 요구사항(선택)


### ✅ 이슈 자동 종료

> 이 PR이 머지될 때 자동으로 이슈를 닫으려면 아래에 작성해주세요.
>
> **Closes #75** 
