### PR TITLE
Refactor: 모달 외부 컨트롤

### DIFF
--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -3,6 +3,7 @@ import { ModalContent, ModalTrigger } from "@/components/common/modal";
 import { ModalContext } from "@/hooks";
 import React, { useState, type ReactElement } from "react";
 import { createPortal } from "react-dom";
+import type { ModalContextType } from "@/types";
 
 type ModalChildren =
   | ReactElement<typeof ModalTrigger>
@@ -11,16 +12,31 @@ type ModalChildren =
 interface ModalProps {
   children: ModalChildren | ModalChildren[];
   isOverlay?: boolean;
+  externalModalControl?: ModalContextType;
 }
 
-export default function Modal({ children, isOverlay = true }: ModalProps) {
-  const [isOpen, setIsOpen] = useState(false);
+export default function Modal({
+  children,
+  isOverlay = true,
+  externalModalControl,
+}: ModalProps) {
+  const [isInternalOpen, setIsInternalOpen] = useState(false);
 
-  const open = () => setIsOpen(true);
+  const isOpen = externalModalControl
+    ? externalModalControl.isOpen
+    : isInternalOpen;
 
-  const close = () => setIsOpen(false);
+  const open = externalModalControl
+    ? externalModalControl.open
+    : () => setIsInternalOpen(true);
 
-  const toggle = () => setIsOpen((prev) => !prev);
+  const close = externalModalControl
+    ? externalModalControl.close
+    : () => setIsInternalOpen(false);
+
+  const toggle = externalModalControl
+    ? externalModalControl.toggle
+    : () => setIsInternalOpen((prev) => !prev);
 
   const modalRoot = document.getElementById("modal-root")!;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #84

## 📝작업 내용

> 모달 외부 컨트롤 prop 추가

+ 외부 컨트롤 prop을 전달하지 않으면 기존이랑 동일하게 작동합니다.

+ 쪽지 시험에서 경고 모달 출력할 때 사용 가능할 것 같습니다.

+ 예시 코드
```typescript
  const [open, setIsOpen] = useState(false);

  const externalModalControl: ModalContextType = {
    isOpen: open,
    open: () => {
      setIsOpen(true);
    },
    close: () => {
      setIsOpen(false);
    },
    toggle: () => {
      setIsOpen((prev) => !prev);
    },
  };

  return (
    <div className="flex flex-col items-center bg-neutral-50 px-5 py-32">
      <Button
        onClick={() => {
          externalModalControl.open();
        }}
      >
        모달 외부 컨트롤
      </Button>

      <Modal externalModalControl={externalModalControl}>
        <ModalContent>hi</ModalContent>
      </Modal>
```

### 스크린샷 (선택)

https://github.com/user-attachments/assets/38540fbf-9be6-4e8b-a741-2342ebbf750d


## 💬리뷰 요구사항(선택)

> 사용법에 궁금한점 있으면 말씀해주세요!

### ✅ 이슈 자동 종료

> 이 PR이 머지될 때 자동으로 이슈를 닫으려면 아래에 작성해주세요.
>
> **Closes #84**
