### PR TITLE
Feature: useExternalModalController 훅

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,6 +3,7 @@ import useWindowSize from "@/hooks/useWindowSize";
 import useOutsideInteraction from "@/hooks/useOutsideInteraction";
 import useModalContext, { ModalContext } from "@/hooks/useModalContext";
 import useInfiniteScroll from "@/hooks/useInfiniteScroll";
+import useExternalModalController from "@/hooks/useExternalModalContoller";
 
 export {
   useToast,
@@ -11,4 +12,5 @@ export {
   useModalContext,
   ModalContext,
   useInfiniteScroll,
+  useExternalModalController,
 };

--- a/src/hooks/useExternalModalContoller.ts
+++ b/src/hooks/useExternalModalContoller.ts
@@ -1,0 +1,21 @@
+import type { ModalContextType } from "@/types";
+import { useState } from "react";
+
+export default function useExternalModalController() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const modalController: ModalContextType = {
+    isOpen: isModalOpen,
+    open: () => {
+      setIsModalOpen(true);
+    },
+    close: () => {
+      setIsModalOpen(false);
+    },
+    toggle: () => {
+      setIsModalOpen((prev) => !prev);
+    },
+  };
+
+  return modalController;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #88

## 📝작업 내용

> 외부 모달 컨트롤러를 생성해주는 useExternalModalController 훅

+ 사용 예시
```typescript
  const modalController = useExternalModalController();

  return (
    <div className="flex flex-col items-center bg-neutral-50 px-5 py-32">
      <Button onClick={modalController.open}>하이</Button>
      <Modal externalModalControl={modalController}>
        <ModalContent>하이</ModalContent>
      </Modal>
```


### ✅ 이슈 자동 종료

> 이 PR이 머지될 때 자동으로 이슈를 닫으려면 아래에 작성해주세요.
>
> **Closes #88** 
