### PR TITLE
Feature: 탈퇴회원복구 모달

### DIFF
--- a/src/components/account-restore-modal/AccountRestoreAlertModal.tsx
+++ b/src/components/account-restore-modal/AccountRestoreAlertModal.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@/components/common";
+import { Modal, ModalContent } from "@/components/common/modal";
+import type { ModalContextType } from "@/types";
+
+interface AccountRestoreAlertModalProps {
+  externalModalControl: ModalContextType;
+  setStep: React.Dispatch<React.SetStateAction<1 | 2 | 3>>;
+}
+
+export default function AccountRestoreAlertModal({
+  externalModalControl,
+  setStep,
+}: AccountRestoreAlertModalProps) {
+  return (
+    <Modal externalModalControl={externalModalControl}>
+      <ModalContent>
+        <Button
+          onClick={() => {
+            setStep(2);
+          }}
+        >
+          계정 다시 사용하기
+        </Button>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/components/account-restore-modal/AccountRestoreAlertModal.tsx
+++ b/src/components/account-restore-modal/AccountRestoreAlertModal.tsx
@@ -6,12 +6,18 @@ import { MehIcon } from "lucide-react";
 interface AccountRestoreAlertModalProps {
   externalModalControl: ModalContextType;
   setStep: React.Dispatch<React.SetStateAction<1 | 2 | 3>>;
+  expiredAt: Date;
 }
 
 export default function AccountRestoreAlertModal({
   externalModalControl,
   setStep,
+  expiredAt,
 }: AccountRestoreAlertModalProps) {
+  const expiredYear = expiredAt.getFullYear();
+  const expiredMonth = expiredAt.getMonth();
+  const expiredDate = expiredAt.getDate();
+
   return (
     <Modal externalModalControl={externalModalControl}>
       <ModalContent className="flex flex-col gap-10">
@@ -21,7 +27,7 @@ export default function AccountRestoreAlertModal({
             해당 계정은 탈퇴된 상태에요.
           </span>
           <div className="flex flex-col items-center text-neutral-400">
-            <span>2025년 6월 20일 이후, 계정 정보는 완전히 삭제돼요.</span>
+            <span>{`${expiredYear}년 ${expiredMonth}월 ${expiredDate}일 이후, 계정 정보는 완전히 삭제돼요.`}</span>
             <span>
               계정을 다시 사용하려면 아래 버튼을 눌러 복구를 진행해주세요.
             </span>

--- a/src/components/account-restore-modal/AccountRestoreAlertModal.tsx
+++ b/src/components/account-restore-modal/AccountRestoreAlertModal.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/common";
 import { Modal, ModalContent } from "@/components/common/modal";
 import type { ModalContextType } from "@/types";
+import { MehIcon } from "lucide-react";
 
 interface AccountRestoreAlertModalProps {
   externalModalControl: ModalContextType;
@@ -13,11 +14,24 @@ export default function AccountRestoreAlertModal({
 }: AccountRestoreAlertModalProps) {
   return (
     <Modal externalModalControl={externalModalControl}>
-      <ModalContent>
+      <ModalContent className="flex flex-col gap-10">
+        <div className="flex flex-col items-center gap-4">
+          <MehIcon className="bg-primary-300 text-primary-500 size-10 rounded-full p-2" />
+          <span className="text-xl font-semibold">
+            해당 계정은 탈퇴된 상태에요.
+          </span>
+          <div className="flex flex-col items-center text-neutral-400">
+            <span>2025년 6월 20일 이후, 계정 정보는 완전히 삭제돼요.</span>
+            <span>
+              계정을 다시 사용하려면 아래 버튼을 눌러 복구를 진행해주세요.
+            </span>
+          </div>
+        </div>
         <Button
           onClick={() => {
             setStep(2);
           }}
+          className="w-full"
         >
           계정 다시 사용하기
         </Button>

--- a/src/components/account-restore-modal/AccountRestoreCompleteModal.tsx
+++ b/src/components/account-restore-modal/AccountRestoreCompleteModal.tsx
@@ -1,0 +1,18 @@
+import { Modal, ModalContent } from "@/components/common/modal";
+import type { ModalContextType } from "@/types";
+
+interface AccountRestoreCompleteModalProps {
+  externalModalControl: ModalContextType;
+}
+
+export default function AccountRestoreCompleteModal({
+  externalModalControl,
+}: AccountRestoreCompleteModalProps) {
+  return (
+    <Modal externalModalControl={externalModalControl}>
+      <ModalContent hasCloseIcon={false}>
+        <span>계정 복구 완료</span>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/components/account-restore-modal/AccountRestoreCompleteModal.tsx
+++ b/src/components/account-restore-modal/AccountRestoreCompleteModal.tsx
@@ -1,5 +1,6 @@
 import { Modal, ModalContent } from "@/components/common/modal";
 import type { ModalContextType } from "@/types";
+import { CheckIcon } from "lucide-react";
 
 interface AccountRestoreCompleteModalProps {
   externalModalControl: ModalContextType;
@@ -10,8 +11,13 @@ export default function AccountRestoreCompleteModal({
 }: AccountRestoreCompleteModalProps) {
   return (
     <Modal externalModalControl={externalModalControl}>
-      <ModalContent hasCloseIcon={false}>
-        <span>계정 복구 완료</span>
+      <ModalContent
+        hasCloseIcon={false}
+        className="flex flex-col items-center gap-4"
+      >
+        <CheckIcon className="bg-success size-8 rounded-full p-1 text-white" />
+        <span className="text-xl font-bold">계정 복구 완료!</span>
+        <span className="text-neutral-600">지금 바로 로그인 해보세요.</span>
       </ModalContent>
     </Modal>
   );

--- a/src/components/account-restore-modal/AccountRestoreFormModal.tsx
+++ b/src/components/account-restore-modal/AccountRestoreFormModal.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@/components/common";
+import { Modal, ModalContent } from "@/components/common/modal";
+import type { ModalContextType } from "@/types";
+
+interface AccountRestoreFormModalProps {
+  externalModalControl: ModalContextType;
+  setStep: React.Dispatch<React.SetStateAction<1 | 2 | 3>>;
+}
+
+export default function AccountRestoreFormModal({
+  externalModalControl,
+  setStep,
+}: AccountRestoreFormModalProps) {
+  return (
+    <Modal externalModalControl={externalModalControl}>
+      <ModalContent>
+        <Button
+          onClick={() => {
+            setStep(3);
+          }}
+        >
+          확인
+        </Button>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/src/components/account-restore-modal/AccountRestoreFormModal.tsx
+++ b/src/components/account-restore-modal/AccountRestoreFormModal.tsx
@@ -6,6 +6,10 @@ import type { ModalContextType } from "@/types";
 import { RotateCwIcon } from "lucide-react";
 import { useState } from "react";
 
+const emailRegex = new RegExp(
+  "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+);
+
 interface AccountRestoreFormModalProps {
   externalModalControl: ModalContextType;
   setStep: React.Dispatch<React.SetStateAction<1 | 2 | 3>>;
@@ -19,6 +23,7 @@ export default function AccountRestoreFormModal({
   const [verificationCode, setVerificationCode] = useState("");
   const [isEmailSent, setIsEmailSent] = useState(false);
   const [isVerified, setIsVerified] = useState(false);
+  const [isEmail, setIsEmail] = useState(false);
 
   const { triggerToast } = useToast();
 
@@ -98,12 +103,13 @@ export default function AccountRestoreFormModal({
               value={email}
               onChange={(e) => {
                 setEmail(e.target.value);
+                setIsEmail(emailRegex.test(email));
               }}
               disabled={isEmailSent}
             />
             <Button
               className="flex h-12 items-center justify-center"
-              disabled={!email || isEmailSent}
+              disabled={!isEmail || isEmailSent}
               onClick={handleEmailButtonClick}
             >
               인증코드전송

--- a/src/components/account-restore-modal/AccountRestoreFormModal.tsx
+++ b/src/components/account-restore-modal/AccountRestoreFormModal.tsx
@@ -1,6 +1,10 @@
-import { Button } from "@/components/common";
+import { Button, Input } from "@/components/common";
 import { Modal, ModalContent } from "@/components/common/modal";
+import { useToast } from "@/hooks";
+import { useSendEmail, useVerifyEmail } from "@/hooks/api";
 import type { ModalContextType } from "@/types";
+import { RotateCwIcon } from "lucide-react";
+import { useState } from "react";
 
 interface AccountRestoreFormModalProps {
   externalModalControl: ModalContextType;
@@ -11,13 +15,126 @@ export default function AccountRestoreFormModal({
   externalModalControl,
   setStep,
 }: AccountRestoreFormModalProps) {
+  const [email, setEmail] = useState("");
+  const [verificationCode, setVerificationCode] = useState("");
+  const [isEmailSent, setIsEmailSent] = useState(false);
+  const [isVerified, setIsVerified] = useState(false);
+
+  const { triggerToast } = useToast();
+
+  const { mutate: sendEmail } = useSendEmail({
+    onSuccess: () => {
+      setIsEmailSent(true);
+      triggerToast({
+        variant: "small",
+        status: "success",
+        text: "전송 완료! 이메일을 확인해주세요.",
+      });
+    },
+    onError: () => {
+      triggerToast({
+        variant: "small",
+        status: "danger",
+        text: "이메일 전송에 실패했습니다. 잠시후 다시 시도해주세요.",
+      });
+    },
+  });
+
+  const { mutate: verifyEmail } = useVerifyEmail({
+    onSuccess: () => {
+      setIsVerified(true);
+      triggerToast({
+        variant: "small",
+        status: "success",
+        text: "이메일 인증 완료! 확인 버튼을 클릭해주세요.",
+      });
+    },
+    onError: (error) => {
+      if (error.status === 403) {
+        triggerToast({
+          variant: "small",
+          status: "danger",
+          text: "올바르지 않은 인증코드입니다.",
+        });
+      } else {
+        triggerToast({
+          variant: "small",
+          status: "danger",
+          text: "이메일 인증에 실패했습니다. 잠시후 다시 시도해주세요.",
+        });
+      }
+    },
+  });
+
+  const handleEmailButtonClick = () => {
+    sendEmail({ email });
+  };
+
+  const handleVerifyButtonClick = () => {
+    verifyEmail({ email, code: verificationCode });
+  };
+
   return (
     <Modal externalModalControl={externalModalControl}>
-      <ModalContent>
+      <ModalContent className="flex w-full max-w-md flex-col gap-8">
+        <div className="flex flex-col items-center gap-4">
+          <RotateCwIcon className="bg-primary-300 text-primary-500 size-10 rounded-full p-2" />
+          <span className="text-xl font-semibold">계정 다시 사용하기</span>
+          <span className="text-neutral-400">
+            입력하신 이메일로 인증번호를 보내드릴게요.
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <span>
+            이메일<span className="text-danger">*</span>
+          </span>
+
+          <div className="flex items-center justify-center gap-2">
+            <Input
+              placeholder="가입한 이메일을 입력해주세요."
+              className="flex-1"
+              inputClassName="h-12"
+              value={email}
+              onChange={(e) => {
+                setEmail(e.target.value);
+              }}
+              disabled={isEmailSent}
+            />
+            <Button
+              className="flex h-12 items-center justify-center"
+              disabled={!email || isEmailSent}
+              onClick={handleEmailButtonClick}
+            >
+              인증코드전송
+            </Button>
+          </div>
+
+          <div className="flex items-center justify-center gap-2">
+            <Input
+              placeholder="인증번호를 입력해주세요."
+              className="flex-1"
+              inputClassName="h-12"
+              value={verificationCode}
+              onChange={(e) => {
+                setVerificationCode(e.target.value);
+              }}
+            />
+            <Button
+              className="flex h-12 items-center justify-center"
+              disabled={!isEmailSent || !verificationCode}
+              onClick={handleVerifyButtonClick}
+            >
+              인증코드확인
+            </Button>
+          </div>
+        </div>
+
         <Button
           onClick={() => {
             setStep(3);
           }}
+          disabled={!isVerified}
         >
           확인
         </Button>

--- a/src/components/account-restore-modal/AccountRestoreModal.tsx
+++ b/src/components/account-restore-modal/AccountRestoreModal.tsx
@@ -8,10 +8,12 @@ import {
 
 interface AccountRestoreModalProps {
   externalModalControl: ModalContextType;
+  expiredAt: Date;
 }
 
 export default function AccountRestoreModal({
   externalModalControl,
+  expiredAt,
 }: AccountRestoreModalProps) {
   const [step, setStep] = useState<1 | 2 | 3>(1);
 
@@ -20,6 +22,7 @@ export default function AccountRestoreModal({
       <AccountRestoreAlertModal
         externalModalControl={externalModalControl}
         setStep={setStep}
+        expiredAt={expiredAt}
       />
     );
   } else if (step === 2) {

--- a/src/components/account-restore-modal/AccountRestoreModal.tsx
+++ b/src/components/account-restore-modal/AccountRestoreModal.tsx
@@ -1,0 +1,39 @@
+import type { ModalContextType } from "@/types";
+import { useState } from "react";
+import {
+  AccountRestoreAlertModal,
+  AccountRestoreCompleteModal,
+  AccountRestoreFormModal,
+} from "@/components/";
+
+interface AccountRestoreModalProps {
+  externalModalControl: ModalContextType;
+}
+
+export default function AccountRestoreModal({
+  externalModalControl,
+}: AccountRestoreModalProps) {
+  const [step, setStep] = useState<1 | 2 | 3>(1);
+
+  if (step === 1) {
+    return (
+      <AccountRestoreAlertModal
+        externalModalControl={externalModalControl}
+        setStep={setStep}
+      />
+    );
+  } else if (step === 2) {
+    return (
+      <AccountRestoreFormModal
+        externalModalControl={externalModalControl}
+        setStep={setStep}
+      />
+    );
+  } else {
+    return (
+      <AccountRestoreCompleteModal
+        externalModalControl={externalModalControl}
+      />
+    );
+  }
+}

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -4,6 +4,10 @@ import ExamCategorySelector from "@/components/ExamCategorySelector";
 import SubjectThumbnail from "@/components/SubjectThumbnail";
 import ExamEntryModal from "@/components/ExamEntryModal";
 import ExamList from "@/components/ExamList";
+import AccountRestoreModal from "@/components/account-restore-modal/AccountRestoreModal";
+import AccountRestoreAlertModal from "@/components/account-restore-modal/AccountRestoreAlertModal";
+import AccountRestoreFormModal from "@/components/account-restore-modal/AccountRestoreFormModal";
+import AccountRestoreCompleteModal from "@/components/account-restore-modal/AccountRestoreCompleteModal";
 
 export {
   Footer,
@@ -12,4 +16,8 @@ export {
   SubjectThumbnail,
   ExamEntryModal,
   ExamList,
+  AccountRestoreModal,
+  AccountRestoreAlertModal,
+  AccountRestoreFormModal,
+  AccountRestoreCompleteModal,
 };

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -7,11 +7,12 @@ import type { LoginRequest } from "@/types/api-request-type/auth-request-type";
 import type {
   LoginResponse,
   ErrorResponse,
+  ExpiredAccountErrorResponse,
 } from "@/types/api-response-type/auth-response-type";
 
 type LoginMutationOptions = UseMutationOptions<
   LoginResponse,
-  AxiosError<ErrorResponse>,
+  AxiosError<ErrorResponse | ExpiredAccountErrorResponse>,
   LoginRequest
 >;
 
@@ -30,13 +31,6 @@ export const useLoginMutation = (options?: LoginMutationOptions) => {
 
       if (options?.onSuccess) {
         options.onSuccess(data, variables, context);
-      }
-    },
-    onError: (error, variables, context) => {
-      console.log("로그인 실패...", error);
-
-      if (options?.onError) {
-        options.onError(error, variables, context);
       }
     },
   });

--- a/src/mocks/handlers/auth-handlers.ts
+++ b/src/mocks/handlers/auth-handlers.ts
@@ -5,15 +5,27 @@ import type { LoginRequest } from "@/types/api-request-type/auth-request-type";
 import type {
   LoginResponse,
   ErrorResponse,
+  ExpiredAccountErrorResponse,
 } from "@/types/api-response-type/auth-response-type";
 
 const loginHandler = http.post<
   PathParams,
   LoginRequest,
-  LoginResponse | ErrorResponse
+  LoginResponse | ErrorResponse | ExpiredAccountErrorResponse
 >(`${MSW_BASE_URL}${API_PATHS.accounts.login}`, async ({ request }) => {
   const requestBody = await request.json();
   const { email, password } = requestBody;
+
+  if (email === "expired@gmail.com") {
+    const response: ExpiredAccountErrorResponse = {
+      error_detail: {
+        detail: "탈퇴 신청한 계정입니다.",
+        expire_at: "2025-11-11",
+      },
+    };
+
+    return HttpResponse.json(response, { status: 403 });
+  }
 
   if (email === "test@gmail.com" && password === "1234") {
     return HttpResponse.json(mockLoginResponse, { status: 200 });

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -6,9 +6,33 @@ import { LoginSchema, type LoginSchemaType } from "@/schemas/authSchemas";
 import HeaderLogo from "@/assets/images/logo-images/header-logo.svg";
 import { KakaoLoginButton, NaverLoginButton } from "@/components/auth";
 import { useLoginMutation } from "@/hooks/useLogin";
+import { useExternalModalController } from "@/hooks";
+import { AccountRestoreModal } from "@/components";
+import { useState } from "react";
 
 export default function LoginPage() {
-  const { mutate: loginFn, isPending, isError, error } = useLoginMutation();
+  const accountRestoreModalControl = useExternalModalController();
+
+  const [expiredDate, setExpiredDate] = useState<Date>();
+
+  const {
+    mutate: loginFn,
+    isPending,
+    isError,
+  } = useLoginMutation({
+    onError: (error) => {
+      if (
+        error.response &&
+        error.response.status === 403 &&
+        error.response.data &&
+        "error_detail" in error.response.data &&
+        "expire_at" in error.response.data.error_detail
+      ) {
+        setExpiredDate(new Date(error.response.data.error_detail.expire_at));
+        accountRestoreModalControl.open();
+      }
+    },
+  });
 
   const {
     register,
@@ -25,6 +49,11 @@ export default function LoginPage() {
 
   return (
     <div className="flex min-h-screen flex-col items-center py-12 sm:px-6 lg:px-8">
+      <AccountRestoreModal
+        externalModalControl={accountRestoreModalControl}
+        expiredAt={expiredDate || new Date()}
+      />
+
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <Link to="/" className="flex justify-center">
           <img src={HeaderLogo} alt="OZ Coding School" />
@@ -80,7 +109,7 @@ export default function LoginPage() {
 
             {isError && (
               <div className="mb-2 text-center text-sm font-medium text-red-500">
-                {error?.response?.data?.message || "로그인에 실패했습니다."}
+                {"로그인에 실패했습니다."}
               </div>
             )}
 

--- a/src/types/api-response-type/auth-response-type.ts
+++ b/src/types/api-response-type/auth-response-type.ts
@@ -14,3 +14,10 @@ export interface LoginResponse {
 export interface ErrorResponse {
   message: string;
 }
+
+export interface ExpiredAccountErrorResponse {
+  error_detail: {
+    detail: string;
+    expire_at: string;
+  };
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #93

## 📝작업 내용

> 탈퇴회원복구 모달

- 3단계에 나눈 모달
- 로그인 msw에 탈퇴 계정 케이스 추가
- 403 에러 발생 시 자동으로 탈퇴 회원 복구 모달 트리거
- 탈퇴회원 복구 폼이 별로 복잡하지 않아 react-hook-form을 사용하지 않았습니다.

### 스크린샷 (선택)

https://github.com/user-attachments/assets/103ebdc1-4862-43c9-a4e7-703d531fd813




### ✅ 이슈 자동 종료

> 이 PR이 머지될 때 자동으로 이슈를 닫으려면 아래에 작성해주세요.
>
> **Closes #93** 
