### PR TITLE
Feature: 쪽지시험 문제 컴포넌트

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -8,6 +8,7 @@ import AccountRestoreModal from "@/components/account-restore-modal/AccountResto
 import AccountRestoreAlertModal from "@/components/account-restore-modal/AccountRestoreAlertModal";
 import AccountRestoreFormModal from "@/components/account-restore-modal/AccountRestoreFormModal";
 import AccountRestoreCompleteModal from "@/components/account-restore-modal/AccountRestoreCompleteModal";
+import ExamQuestion from "@/components/question/ExamQuestion";
 
 export {
   Footer,
@@ -20,4 +21,5 @@ export {
   AccountRestoreAlertModal,
   AccountRestoreFormModal,
   AccountRestoreCompleteModal,
+  ExamQuestion,
 };

--- a/src/components/question/ExamQuestion.tsx
+++ b/src/components/question/ExamQuestion.tsx
@@ -1,0 +1,46 @@
+import { EXAM_QUESTION_TYPE_LABEL_MAP } from "@/constants";
+import { cn } from "@/lib";
+import type { Question } from "@/types";
+import { EXAM_QUESTION_CONTENT_MAP } from "@/components/question/exam-question-content-map";
+
+interface ExamQuestionProps {
+  question: Question;
+  value: string | string[] | null;
+  onChange: (
+    questionId: number,
+    submittedAnswer: string | string[] | null
+  ) => void;
+}
+
+const BADGE_BASE =
+  "flex h-6 items-center rounded-xs bg-neutral-200 text-neutral-700";
+
+function ExamQuestion({ question, value, onChange }: ExamQuestionProps) {
+  const ContentComponent = EXAM_QUESTION_CONTENT_MAP[question.type];
+
+  return (
+    <li>
+      <div className="flex items-start gap-4">
+        <div className="flex max-w-4/5 gap-3 text-xl font-bold">
+          <span>{question.number}.</span>
+          <span className="tracking-tighter">{question.question}</span>
+        </div>
+        <div className="mt-0.5 flex gap-2 text-xs font-semibold">
+          <div className={cn("px-2", BADGE_BASE)}>{question.point}점</div>
+          <div className={cn("px-2.5", BADGE_BASE)}>
+            {EXAM_QUESTION_TYPE_LABEL_MAP[question.type]}
+          </div>
+        </div>
+      </div>
+      <div className="pt-5 pl-7">
+        <ContentComponent
+          question={question}
+          value={value}
+          onChange={onChange}
+        />
+      </div>
+    </li>
+  );
+}
+
+export default ExamQuestion;

--- a/src/components/question/FillBlank.tsx
+++ b/src/components/question/FillBlank.tsx
@@ -1,0 +1,77 @@
+import { cn } from "@/lib";
+import type { Question } from "@/types";
+import { memo } from "react";
+
+interface FillBlankProps {
+  question: Question;
+  value: string | string[] | null;
+  onChange: (
+    questionId: number,
+    submittedAnswer: string | string[] | null
+  ) => void;
+}
+
+const BLANK_TOKEN = "__";
+
+const BLANK_LABEL_START_CODE = 65;
+
+const FillBlank = memo(function FillBlank({
+  question,
+  value,
+  onChange,
+}: FillBlankProps) {
+  const promptParts = question.prompt?.split(BLANK_TOKEN) ?? [];
+  const answers = Array.isArray(value)
+    ? value
+    : Array.from({ length: question.blank_count ?? 0 }, () => "");
+
+  const handleAnswerChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    index: number
+  ) => {
+    const nextAnswers = [...answers];
+    nextAnswers[index] = event.target.value;
+
+    onChange(question.question_id, nextAnswers);
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="w-3/5 rounded-sm bg-neutral-100 px-6.5 py-4">
+        {promptParts.map((part, index) => (
+          <span key={`${question.question_id}-prompt-${index}`}>
+            {part}
+            {index < promptParts.length - 1 && (
+              <strong>{`(${String.fromCharCode(BLANK_LABEL_START_CODE + index)}) ________`}</strong>
+            )}
+          </span>
+        ))}
+      </div>
+      <div className="flex flex-col gap-2.5">
+        {answers.map((answer, index) => (
+          <label
+            key={`${question.question_id}-answer-${index}`}
+            className="flex h-12 w-4/12 items-center gap-2 rounded-sm bg-neutral-200 px-4"
+          >
+            <span className="text-lg font-bold">
+              {String.fromCharCode(BLANK_LABEL_START_CODE + index)}
+            </span>
+            <input
+              type="text"
+              className={cn(
+                "grow",
+                "placeholder:text-neutral-400",
+                "focus:outline-none"
+              )}
+              placeholder="정답을 입력해 주세요."
+              value={answer}
+              onChange={(event) => handleAnswerChange(event, index)}
+            />
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+});
+
+export default FillBlank;

--- a/src/components/question/MultipleChoice.tsx
+++ b/src/components/question/MultipleChoice.tsx
@@ -1,0 +1,62 @@
+import { cn } from "@/lib";
+import type { Question } from "@/types";
+import { CheckIcon } from "lucide-react";
+import { memo } from "react";
+
+interface MultipleChoiceProps {
+  question: Question;
+  value: string | string[] | null;
+  onChange: (
+    questionId: number,
+    submittedAnswer: string | string[] | null
+  ) => void;
+}
+
+const MultipleChoice = memo(function MultipleChoice({
+  question,
+  value,
+  onChange,
+}: MultipleChoiceProps) {
+  const selectedOptions = Array.isArray(value) ? value : [];
+
+  const handleOptionToggle = (option: string) => {
+    const nextOptions = selectedOptions.includes(option)
+      ? selectedOptions.filter((item) => item !== option)
+      : [...selectedOptions, option];
+
+    onChange(question.question_id, nextOptions);
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      {question.options?.map((option) => (
+        <label
+          key={`${question.question_id}-${option}`}
+          className="relative flex items-center gap-3"
+        >
+          <input
+            type="checkbox"
+            checked={selectedOptions.includes(option)}
+            onChange={() => handleOptionToggle(option)}
+            className={cn(
+              "peer size-5 appearance-none rounded-xs border border-neutral-400 bg-white",
+              "checked:bg-primary-700 checked:border-primary-700",
+              "focus:outline-none"
+            )}
+          />
+          <CheckIcon
+            className={cn(
+              "top-1 left-0.5 hidden text-white",
+              "peer-checked:absolute peer-checked:block"
+            )}
+            size={16}
+            strokeWidth={2.2}
+          />
+          <span>{option}</span>
+        </label>
+      ))}
+    </div>
+  );
+});
+
+export default MultipleChoice;

--- a/src/components/question/Ordering.tsx
+++ b/src/components/question/Ordering.tsx
@@ -1,0 +1,90 @@
+import { cn } from "@/lib";
+import type { Question } from "@/types";
+import { memo, useEffect, useMemo, useState } from "react";
+
+interface OrderingProps {
+  question: Question;
+  value: string | string[] | null;
+  onChange: (
+    questionId: number,
+    submittedAnswer: string | string[] | null
+  ) => void;
+}
+
+const OPTION_LABEL_START_CODE = 65;
+
+const Ordering = memo(function Ordering({
+  question,
+  value: _value,
+  onChange,
+}: OrderingProps) {
+  const [inputValues, setInputValues] = useState<string[]>([]);
+
+  const letterToOptionMap = useMemo(
+    () =>
+      new Map(
+        question.options?.map((option, index) => [
+          String.fromCharCode(OPTION_LABEL_START_CODE + index),
+          option,
+        ])
+      ),
+    [question.options]
+  );
+
+  const handleInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    index: number
+  ) => {
+    const nextInputValues = [...inputValues];
+
+    nextInputValues[index] = event.target.value;
+    setInputValues(nextInputValues);
+
+    const submittedAnswer = nextInputValues.map(
+      (inputValue) => letterToOptionMap.get(inputValue.toUpperCase()) ?? ""
+    );
+
+    onChange(question.question_id, submittedAnswer);
+  };
+
+  useEffect(() => {
+    const initialState = Array.isArray(question.answer_input)
+      ? question.answer_input
+      : Array.from({ length: question.options?.length ?? 0 }, () => "");
+
+    setInputValues(initialState);
+  }, [question.answer_input, question.options?.length]);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex w-3/5 flex-col gap-5 rounded-sm bg-neutral-100 px-4 py-5">
+        {question.options?.map((option, index) => (
+          <div
+            key={`${question.question_id}-ordering-option-${index}`}
+            className="flex items-center gap-2"
+          >
+            <div className="bg-primary-100 text-primary-600 flex size-8 items-center justify-center rounded-sm text-lg font-medium">
+              {String.fromCharCode(OPTION_LABEL_START_CODE + index)}
+            </div>
+            <span>{option}</span>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2.5">
+        {inputValues.map((inputValue, index) => (
+          <input
+            key={`${question.question_id}-ordering-answer-${index}`}
+            className={cn(
+              "size-15.5 rounded-sm bg-neutral-200 p-6 text-center text-xl font-bold",
+              "focus:outline-none"
+            )}
+            value={inputValue}
+            onChange={(event) => handleInputChange(event, index)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+});
+
+export default Ordering;

--- a/src/components/question/Ox.tsx
+++ b/src/components/question/Ox.tsx
@@ -1,0 +1,65 @@
+import { cn } from "@/lib";
+import type { Question } from "@/types";
+import { CheckIcon, CircleIcon, XIcon } from "lucide-react";
+import { memo } from "react";
+
+interface OxProps {
+  question: Question;
+  value: string | string[] | null;
+  onChange: (
+    questionId: number,
+    submittedAnswer: string | string[] | null
+  ) => void;
+}
+
+const OPTIONS = [
+  { label: "맞아요", value: "O" },
+  { label: "아니에요", value: "X" },
+] as const;
+
+const ICON_BASE = "size-5 text-neutral-400";
+
+const ICON_STROKE = 3;
+
+const Ox = memo(function Ox({ question, value, onChange }: OxProps) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      {OPTIONS.map((option) => (
+        <button
+          key={`${question.question_id}-ox-${option.value}`}
+          className={cn(
+            "flex h-12 w-4/12 items-center gap-2 rounded-sm bg-neutral-200 px-4",
+            "focus:outline-none",
+            { "bg-primary-100": option.value === value }
+          )}
+          onClick={() => onChange(question.question_id, option.value)}
+        >
+          {option.value === "O" ? (
+            <CircleIcon
+              className={cn(ICON_BASE, {
+                "text-success": option.value === value,
+              })}
+              strokeWidth={ICON_STROKE}
+            />
+          ) : (
+            <XIcon
+              className={cn(ICON_BASE, {
+                "text-danger": option.value === value,
+              })}
+              strokeWidth={ICON_STROKE}
+            />
+          )}
+          <span className="grow text-start">{option.label}</span>
+          <CheckIcon
+            className={cn(ICON_BASE, {
+              "text-primary-600": option.value === value,
+            })}
+            strokeWidth={ICON_STROKE}
+          />
+        </button>
+      ))}
+    </div>
+  );
+});
+
+export default Ox;

--- a/src/components/question/ShortAnswer.tsx
+++ b/src/components/question/ShortAnswer.tsx
@@ -1,0 +1,37 @@
+import { cn } from "@/lib";
+import type { Question } from "@/types";
+import { memo } from "react";
+
+interface ShortAnswerProps {
+  question: Question;
+  value: string | string[] | null;
+  onChange: (
+    questionId: number,
+    submittedAnswer: string | string[] | null
+  ) => void;
+}
+
+const ShortAnswer = memo(function ShortAnswer({
+  question,
+  value,
+  onChange,
+}: ShortAnswerProps) {
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) =>
+    onChange(question.question_id, event.target.value);
+
+  return (
+    <input
+      type="text"
+      value={value ?? ""}
+      onChange={handleInputChange}
+      placeholder="정답을 입력해 주세요."
+      className={cn(
+        "h-12 w-3/5 rounded-sm bg-neutral-200 px-4",
+        "focus:outline-none",
+        "placeholder:text-neutral-400"
+      )}
+    />
+  );
+});
+
+export default ShortAnswer;

--- a/src/components/question/SingleChoice.tsx
+++ b/src/components/question/SingleChoice.tsx
@@ -1,0 +1,44 @@
+import { cn } from "@/lib";
+import type { Question } from "@/types";
+import { memo } from "react";
+
+interface SingleChoiceProps {
+  question: Question;
+  value: string | string[] | null;
+  onChange: (
+    questionId: number,
+    submittedAnswer: string | string[] | null
+  ) => void;
+}
+
+const SingleChoice = memo(function SingleChoice({
+  question,
+  value,
+  onChange,
+}: SingleChoiceProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      {question.options?.map((option) => (
+        <label
+          key={`${question.question_id}-${option}`}
+          className="flex items-center gap-3"
+        >
+          <input
+            type="radio"
+            name={question.question}
+            className={cn(
+              "size-4 appearance-none rounded-full border-4 border-white bg-neutral-200 shadow-[0_0_0_1px] shadow-neutral-400",
+              "checked:border-primary-700 checked:shadow-primary-700 checked:bg-white",
+              "focus:outline-none"
+            )}
+            checked={option === value}
+            onChange={() => onChange(question.question_id, option)}
+          />
+          <span>{option}</span>
+        </label>
+      ))}
+    </div>
+  );
+});
+
+export default SingleChoice;

--- a/src/components/question/exam-question-content-map.ts
+++ b/src/components/question/exam-question-content-map.ts
@@ -1,0 +1,19 @@
+import type { QuestionType, ExamQuestionContentComponent } from "@/types";
+import SingleChoice from "@/components/question/SingleChoice";
+import MultipleChoice from "@/components/question/MultipleChoice";
+import ShortAnswer from "@/components/question/ShortAnswer";
+import FillBlank from "@/components/question/FillBlank";
+import Ox from "@/components/question/Ox";
+import Ordering from "@/components/question/Ordering";
+
+export const EXAM_QUESTION_CONTENT_MAP: Record<
+  QuestionType,
+  ExamQuestionContentComponent
+> = {
+  single_choice: SingleChoice,
+  multiple_choice: MultipleChoice,
+  short_answer: ShortAnswer,
+  fill_blank: FillBlank,
+  ox: Ox,
+  ordering: Ordering,
+};

--- a/src/constants/exam-constants.ts
+++ b/src/constants/exam-constants.ts
@@ -14,7 +14,7 @@ import {
   ReactNativeIcon,
   TypescriptIcon,
 } from "@/assets/icons/subject-icons";
-import type { ExamCategoryOption } from "@/types";
+import type { ExamCategoryOption, QuestionType } from "@/types";
 
 export const EXAM_CATEGORY_OPTIONS: ExamCategoryOption[] = [
   { label: "전체보기", value: "all" },
@@ -37,4 +37,13 @@ export const EXAM_SUBJECT_ICON_MAP: Record<string, string> = {
   django: DjangoIcon,
   fastapi: FastapiIcon,
   flask: FlaskIcon,
+};
+
+export const EXAM_QUESTION_TYPE_LABEL_MAP: Record<QuestionType, string> = {
+  fill_blank: "빈칸식",
+  multiple_choice: "다중선택",
+  ordering: "순서배열",
+  ox: "OX선택",
+  short_answer: "단답형",
+  single_choice: "단일선택",
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -8,6 +8,7 @@ import {
 import {
   EXAM_CATEGORY_OPTIONS,
   EXAM_SUBJECT_ICON_MAP,
+  EXAM_QUESTION_TYPE_LABEL_MAP,
 } from "@/constants/exam-constants";
 import { MSW_BASE_URL, API_PATHS } from "@/constants/api-paths";
 
@@ -23,4 +24,5 @@ export {
   EXAM_SUBJECT_ICON_MAP,
   MSW_BASE_URL,
   API_PATHS,
+  EXAM_QUESTION_TYPE_LABEL_MAP,
 };

--- a/src/types/exam-types.ts
+++ b/src/types/exam-types.ts
@@ -33,3 +33,34 @@ export interface ExamListResponse {
   has_next: boolean;
   results: Exam[];
 }
+
+export type QuestionType =
+  | "single_choice"
+  | "multiple_choice"
+  | "ox"
+  | "short_answer"
+  | "ordering"
+  | "fill_blank";
+
+export interface Question {
+  question_id: number;
+  number: number;
+  type: QuestionType;
+  question: string;
+  point: number;
+  prompt: string | null;
+  blank_count: number | null;
+  options: string[] | null;
+  answer_input: string | string[] | null;
+}
+
+interface ExamQuestionContentProps {
+  question: Question;
+  value: string | string[] | null;
+  onChange: (
+    questionId: number,
+    submittedAnswer: string | string[] | null
+  ) => void;
+}
+
+export type ExamQuestionContentComponent = React.FC<ExamQuestionContentProps>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,9 @@ import type {
   ExamCategoryOption,
   Exam,
   ExamListResponse,
+  QuestionType,
+  Question,
+  ExamQuestionContentComponent,
 } from "@/types/exam-types";
 
 export type {
@@ -24,4 +27,7 @@ export type {
   ExamCategoryOption,
   Exam,
   ExamListResponse,
+  QuestionType,
+  Question,
+  ExamQuestionContentComponent,
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> #102

## 📝작업 내용

> 쪽지시험 문제 컴포넌트
- 빈칸식
- 다중선택
- 순서배열
- OX선택
- 단답형
- 단일선택
- 렌더링 횟수 최적화 
  - memo 사용 전: 한 문제의 답안을 입력하면 모든 문제의 Content 컴포넌트가 리렌더링 됩니다.
  - memo 사용 후: 한 문제의 답안을 입력하면 입력한 문제의 Content 컴포넌트만 리렌더링 됩니다.
  - 현재 mock 데이터 규모에서는 체감 성능 차이가 크지 않습니다.
다만 데이터 규모가 증가할수록 불필요한 리렌더링이 더 많이 발생하는 구조이므로 이를 방지하기 위해 memo를 적용했습니다.

## 스크린샷

https://github.com/user-attachments/assets/3e02d3ca-bfbb-4f24-8079-cc129c914ee9

## ✅ 이슈 자동 종료

> **Closes #102**
