### PR TITLE
Fix: 쪽지시험이 비활성화 상태일 시 시험 종료 처리되도록 수정

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -9,6 +9,7 @@ import useExamCheatingStatus from "@/hooks/useExamCheatingStatus";
 import useExamCheatingModal from "@/hooks/useExamCheatingModal";
 import useExamAnswers from "@/hooks/useExamAnswers";
 import useExamSubmitControl from "@/hooks/useExamSubmitControl";
+import useExamStatusControl from "@/hooks/useExamStatusControl";
 
 export {
   useToast,
@@ -23,4 +24,5 @@ export {
   useExamCheatingModal,
   useExamAnswers,
   useExamSubmitControl,
+  useExamStatusControl,
 };

--- a/src/hooks/useExamStatusControl.ts
+++ b/src/hooks/useExamStatusControl.ts
@@ -1,0 +1,26 @@
+import { useExamStatusPolling } from "@/hooks/api";
+import { useEffect } from "react";
+import { useNavigate } from "react-router";
+import { useToast } from "@/hooks";
+
+function useExamStatusControl(deploymentId: number) {
+  const { data: examStatusDto } = useExamStatusPolling(deploymentId);
+  const examStatus = examStatusDto?.exam_status;
+  const navigate = useNavigate();
+  const { triggerToast } = useToast();
+
+  useEffect(() => {
+    if (examStatus === "deactivated") {
+      triggerToast({
+        variant: "big",
+        title: "시험이 종료되었습니다.",
+        text: "시험이 비활성화되었습니다.",
+        status: "danger",
+      });
+      navigate("/my-page/exams");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [examStatus]);
+}
+
+export default useExamStatusControl;

--- a/src/pages/TakeExam.tsx
+++ b/src/pages/TakeExam.tsx
@@ -10,10 +10,11 @@ import {
   useExamAnswers,
   useExamCheatingModal,
   useExamCheatingStatus,
+  useExamStatusControl,
   useExamSubmitControl,
   useExamTimer,
 } from "@/hooks";
-import { useExamStatusPolling, useExamQuestionList } from "@/hooks/api";
+import { useExamQuestionList } from "@/hooks/api";
 import { cn } from "@/lib";
 import { ArrowLeftIcon } from "lucide-react";
 import { useState } from "react";
@@ -44,12 +45,9 @@ function TakeExam() {
   const { cheatingCount, isForcedSubmitted } =
     useExamCheatingStatus(deploymentId);
   const { modalControl } = useExamCheatingModal(cheatingCount);
-  const { data: examStatus } = useExamStatusPolling(deploymentId);
+  useExamStatusControl(deploymentId);
 
-  const shouldForceSubmit =
-    hasTimedOut ||
-    isForcedSubmitted ||
-    (examStatus?.exam_status ?? null) === "deactivated";
+  const shouldForceSubmit = hasTimedOut || isForcedSubmitted;
   const { submit, isPending } = useExamSubmitControl(
     startedAt,
     cheatingCount,


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #116 

## 📝작업 내용

> 쪽지시험이 비활성화 상태일 시 시험 종료 처리되도록 수정

- 작업 이전
쪽지시험 상태가 deactivated 인 경우 시험이 강제 제출됨

- 현재
쪽지시험 상태가 deactivated 인 경우 즉시 종료 안내 토스트 띄운 후 쪽지시험 목록 페이지로 이동

## 스크린샷

https://github.com/user-attachments/assets/9b3bafd8-5d31-496a-b32c-08a110cd3d7f

## ✅ 이슈 자동 종료

> **Closes #116 **
