### PR TITLE
Fix: 답안 제출 실패 시 안내 토스트 노출

### DIFF
--- a/src/hooks/useExamSubmitControl.ts
+++ b/src/hooks/useExamSubmitControl.ts
@@ -3,6 +3,9 @@ import { useSubmitExam } from "@/hooks/api";
 import type { Answer, QuestionType, QuestionTypeDto } from "@/types";
 import type { ExamSubmitRequest } from "@/types/api-request-type/exam-request-types";
 import { useNavigate } from "react-router";
+import { useToast } from "@/hooks";
+
+const CHEATING_LIMIT = 3;
 
 function useExamSubmitControl(
   startedAt: number,
@@ -12,18 +15,28 @@ function useExamSubmitControl(
   deploymentId: number
 ) {
   const navigate = useNavigate();
+  const hasSubmittedRef = useRef(false);
+  const { triggerToast } = useToast();
   const { mutate: submitExam, isPending } = useSubmitExam({
     onSuccess: (data) => {
       const redirectUrl = `/exam/${deploymentId}/result/${data.submissionId}`;
 
-      if (cheatingCount > 2) {
+      if (cheatingCount >= CHEATING_LIMIT) {
         setTimeout(() => navigate(redirectUrl), 3000);
         return;
       }
       navigate(redirectUrl);
     },
+    onError: () => {
+      triggerToast({
+        variant: "big",
+        title: "답안 제출 실패",
+        text: "잠시 후에 다시 시도해 주세요.",
+        status: "danger",
+      });
+      hasSubmittedRef.current = false;
+    },
   });
-  const hasSubmittedRef = useRef(false);
 
   const submit = useCallback(
     () => submitExam(buildSubmitPayload(startedAt, cheatingCount, answers)),

--- a/src/hooks/useExamSubmitControl.ts
+++ b/src/hooks/useExamSubmitControl.ts
@@ -4,6 +4,7 @@ import type { Answer, QuestionType, QuestionTypeDto } from "@/types";
 import type { ExamSubmitRequest } from "@/types/api-request-type/exam-request-types";
 import { useNavigate } from "react-router";
 import { useToast } from "@/hooks";
+import type { AxiosResponse } from "axios";
 
 const CHEATING_LIMIT = 3;
 
@@ -27,11 +28,11 @@ function useExamSubmitControl(
       }
       navigate(redirectUrl);
     },
-    onError: () => {
+    onError: (error) => {
       triggerToast({
         variant: "big",
         title: "답안 제출 실패",
-        text: "잠시 후에 다시 시도해 주세요.",
+        text: getToastErrorText(error.response?.data),
         status: "danger",
       });
       hasSubmittedRef.current = false;
@@ -77,4 +78,14 @@ const QUESTION_TYPE_MAP: Record<QuestionType, QuestionTypeDto> = {
   ox: "ox",
   shortAnswer: "short_answer",
   singleChoice: "single_choice",
+};
+
+const getToastErrorText = (data: AxiosResponse["data"]) => {
+  const fallback = "일시적인 오류로 답안 제출에 실패했습니다.";
+
+  if (!data) return fallback;
+  const { error_detail: errorDetail } = data;
+
+  if (typeof errorDetail === "string") return errorDetail;
+  return fallback;
 };

--- a/src/mocks/handlers/exam-handlers.ts
+++ b/src/mocks/handlers/exam-handlers.ts
@@ -130,6 +130,7 @@ const submitExam = http.post(
     //   { error_detail: "자격 인증 데이터가 제공되지 않았습니다." },
     //   { status: 401 }
     // );
+    // return HttpResponse.json(null, { status: 500 });
   }
 );
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #127

## 📝작업 내용

> 답안 제출 실패 시 안내 토스트 노출

- 작업 이전
답안 제출 실패 시 사용자에게 안내 없음

- 현재
  - 답안 제출 실패 시 안내 토스트 노출
  - error 응답에 error_detail 필드가 있다면 error_detail, 없다면 fallback 문구 표출

## 스크린샷

https://github.com/user-attachments/assets/11c6a5ea-d608-4846-9007-45c520667905

## ✅ 이슈 자동 종료

> **Closes #127**
