### PR TITLE
Fix: 시험 종료 안내 모달 닫을 시 즉시 강제 이동 처리

### DIFF
--- a/src/hooks/useExamSubmitControl.ts
+++ b/src/hooks/useExamSubmitControl.ts
@@ -6,28 +6,24 @@ import { useNavigate } from "react-router";
 import { useToast } from "@/hooks";
 import type { AxiosResponse } from "axios";
 
-const CHEATING_LIMIT = 3;
-
 function useExamSubmitControl(
   startedAt: number,
   cheatingCount: number,
   answers: Record<number, Answer>,
   shouldForceSubmit: boolean,
-  deploymentId: number
+  deploymentId: number,
+  isCheatingModalOpen: boolean
 ) {
   const navigate = useNavigate();
   const hasSubmittedRef = useRef(false);
+  const hasNavigatedRef = useRef(false);
   const { triggerToast } = useToast();
-  const { mutate: submitExam, isPending } = useSubmitExam({
-    onSuccess: (data) => {
-      const redirectUrl = `/exam/${deploymentId}/result/${data.submissionId}`;
-
-      if (cheatingCount >= CHEATING_LIMIT) {
-        setTimeout(() => navigate(redirectUrl), 3000);
-        return;
-      }
-      navigate(redirectUrl);
-    },
+  const {
+    mutate: submitExam,
+    isPending,
+    isSuccess,
+    data,
+  } = useSubmitExam({
     onError: (error) => {
       triggerToast({
         variant: "big",
@@ -51,6 +47,26 @@ function useExamSubmitControl(
     hasSubmittedRef.current = true;
     submit();
   }, [shouldForceSubmit, submit]);
+
+  useEffect(() => {
+    if (!isSuccess || !data) return;
+    if (hasNavigatedRef.current) return;
+
+    const redirectUrl = `/exam/${deploymentId}/result/${data.submissionId}`;
+    const handleNavigate = () => {
+      hasNavigatedRef.current = true;
+      navigate(redirectUrl, { replace: true });
+    };
+
+    if (!isCheatingModalOpen) {
+      handleNavigate();
+      return;
+    }
+    const timeoutId = setTimeout(handleNavigate, 3000);
+
+    return () => clearTimeout(timeoutId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, deploymentId, isCheatingModalOpen, isSuccess]);
 
   return { submit, isPending };
 }

--- a/src/pages/TakeExam.tsx
+++ b/src/pages/TakeExam.tsx
@@ -54,7 +54,8 @@ function TakeExam() {
     cheatingCount,
     answers,
     shouldForceSubmit,
-    deploymentId
+    deploymentId,
+    modalControl.isOpen
   );
 
   const handleExamSubmit = () => {


### PR DESCRIPTION
## 연관된 이슈

> ex) #130

## :pencil:작업 내용

> 부정행위 횟수 초과 시 강제 이동 로직 수정

- 작업 이전
  - 사용자가 모달을 닫았는지 여부와 관계없이 3초 후 자동 이동

- 현재
  - 사용자가 모달을 닫은 경우 즉시 이동
  - 사용자가 모달을 닫지 않은 경우 3초 후 자동 이동

## 스크린샷

https://github.com/user-attachments/assets/71d35844-ffb2-4f9b-8073-08d89dcd5013

## :white_check_mark: 이슈 자동 종료

> **Closes #130**