### PR TITLE
Fix: 시험 종료 시 타이머가 정지되도록 수정

### DIFF
--- a/src/hooks/useExamSubmitControl.ts
+++ b/src/hooks/useExamSubmitControl.ts
@@ -12,7 +12,8 @@ function useExamSubmitControl(
   answers: Record<number, Answer>,
   shouldForceSubmit: boolean,
   deploymentId: number,
-  isCheatingModalOpen: boolean
+  isCheatingModalOpen: boolean,
+  stopTimer: () => void
 ) {
   const navigate = useNavigate();
   const hasSubmittedRef = useRef(false);
@@ -45,8 +46,9 @@ function useExamSubmitControl(
     if (hasSubmittedRef.current) return;
 
     hasSubmittedRef.current = true;
+    stopTimer();
     submit();
-  }, [shouldForceSubmit, submit]);
+  }, [shouldForceSubmit, submit, stopTimer]);
 
   useEffect(() => {
     if (!isSuccess || !data) return;

--- a/src/hooks/useExamTimer.ts
+++ b/src/hooks/useExamTimer.ts
@@ -1,24 +1,39 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 function useExamTimer(durationMinutes: number) {
   const startedAtRef = useRef(Date.now());
   const endsAtRef = useRef(startedAtRef.current + durationMinutes * 1000 * 60);
+  const intervalIdRef = useRef<NodeJS.Timeout>(null);
   const [remainingMs, setRemainingMs] = useState(
     endsAtRef.current - startedAtRef.current
   );
   const hasTimedOut = remainingMs <= 0;
 
+  const stopTimer = useCallback(() => {
+    if (!intervalIdRef.current) return;
+
+    clearInterval(intervalIdRef.current);
+    intervalIdRef.current = null;
+  }, []);
+
   useEffect(() => {
     if (hasTimedOut) return;
+    if (intervalIdRef.current) return;
 
     const intervalId = setInterval(() => {
       setRemainingMs(Math.max(0, endsAtRef.current - Date.now()));
     }, 1000);
+    intervalIdRef.current = intervalId;
 
-    return () => clearInterval(intervalId);
-  }, [hasTimedOut]);
+    return stopTimer;
+  }, [hasTimedOut, stopTimer]);
 
-  return { startedAt: startedAtRef.current, remainingMs, hasTimedOut };
+  return {
+    startedAt: startedAtRef.current,
+    remainingMs,
+    hasTimedOut,
+    stopTimer,
+  };
 }
 
 export default useExamTimer;

--- a/src/pages/TakeExam.tsx
+++ b/src/pages/TakeExam.tsx
@@ -42,7 +42,8 @@ function TakeExam() {
   const { answers, hasUnansweredQuestions, handleAnswerChange } =
     useExamAnswers(examDto?.questions ?? null);
 
-  const { startedAt, remainingMs, hasTimedOut } = useExamTimer(durationTime);
+  const { startedAt, remainingMs, hasTimedOut, stopTimer } =
+    useExamTimer(durationTime);
   const { cheatingCount, isForcedSubmitted } =
     useExamCheatingStatus(deploymentId);
   const { modalControl } = useExamCheatingModal(cheatingCount);
@@ -55,11 +56,13 @@ function TakeExam() {
     answers,
     shouldForceSubmit,
     deploymentId,
-    modalControl.isOpen
+    modalControl.isOpen,
+    stopTimer
   );
 
   const handleExamSubmit = () => {
     if (!hasUnansweredQuestions) {
+      stopTimer();
       submit();
       return;
     }


### PR DESCRIPTION
## 연관된 이슈

> ex) #132

## :pencil:작업 내용

> 시험 종료 시 타이머가 정지되도록 수정

- 작업 이전
  - 시험이 종료되어도 타이머가 계속 동작함

- 현재
  - 시험이 종료되면 타이머를 즉시 정지

## 스크린샷

https://github.com/user-attachments/assets/133f4a90-251a-4a3a-94a3-2ace3aadd67d

## :white_check_mark: 이슈 자동 종료

> **Closes #132**