### PR TITLE
Feature: refreshToken을 통한 accessToken 연장

### DIFF
--- a/src/constants/api-paths.ts
+++ b/src/constants/api-paths.ts
@@ -39,7 +39,7 @@ export const API_PATHS = {
       verfiySMS: `${API_PREFIX}${VERIFICATION_API_PREFIX}/verify-sms`,
     },
     me: `${API_PREFIX}/accounts/me`,
-    refresh: `${API_PREFIX}/accounts/me/refresh`,
+    refresh: `${API_PREFIX}/accounts/refresh`,
     changePassword: `${API_PREFIX}/accounts/change-password`,
   },
 } as const;

--- a/src/constants/api-paths.ts
+++ b/src/constants/api-paths.ts
@@ -39,6 +39,7 @@ export const API_PATHS = {
       verfiySMS: `${API_PREFIX}${VERIFICATION_API_PREFIX}/verify-sms`,
     },
     me: `${API_PREFIX}/accounts/me`,
+    refresh: `${API_PREFIX}/accounts/me/refresh`,
     changePassword: `${API_PREFIX}/accounts/change-password`,
   },
 } as const;

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -2,15 +2,7 @@ import { useAuthStore } from "@/store/useAuthStore";
 import axios from "axios";
 import { API_PATHS, API_BASE_URL } from "@/constants/api-paths";
 
-const getCookie = (name: string) => {
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop()?.split(";").shift();
-  return null;
-};
-
 const api = axios.create({
-  baseURL: API_BASE_URL || "",
   withCredentials: true,
   headers: {
     "Content-Type": "application/json",
@@ -40,11 +32,9 @@ api.interceptors.response.use(
       originalRequest._retry = true;
 
       try {
-        const refreshToken = getCookie("refresh_token");
-
         const { data } = await axios.post(
           `${API_BASE_URL}${API_PATHS.accounts.refresh}`,
-          { refresh_token: refreshToken },
+          {},
           { withCredentials: true }
         );
 
@@ -55,13 +45,9 @@ api.interceptors.response.use(
         return api(originalRequest);
       } catch (refreshError) {
         useAuthStore.getState().deleteAccessToken();
-        const refreshToken = getCookie("refresh_token");
-        console.log("읽어온 쿠키 전체:", document.cookie);
-        console.log("추출한 리프레시 토큰:", refreshToken);
         return Promise.reject(refreshError);
       }
     }
-
     return Promise.reject(error);
   }
 );

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,5 +1,6 @@
 import { useAuthStore } from "@/store/useAuthStore";
 import axios from "axios";
+import { API_PATHS, API_BASE_URL } from "@/constants/api-paths";
 
 const api = axios.create({
   withCredentials: true,
@@ -18,6 +19,36 @@ api.interceptors.request.use(
     return config;
   },
   (error) => {
+    return Promise.reject(error);
+  }
+);
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      try {
+        const { data } = await axios.post(
+          `${API_BASE_URL}${API_PATHS.accounts.refresh}`,
+          {},
+          { withCredentials: true }
+        );
+
+        const newAccessToken = data.access_token;
+        useAuthStore.getState().setAccessToken(newAccessToken);
+
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return api(originalRequest);
+      } catch (refreshError) {
+        useAuthStore.getState().deleteAccessToken();
+        return Promise.reject(refreshError);
+      }
+    }
+
     return Promise.reject(error);
   }
 );

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -2,7 +2,15 @@ import { useAuthStore } from "@/store/useAuthStore";
 import axios from "axios";
 import { API_PATHS, API_BASE_URL } from "@/constants/api-paths";
 
+const getCookie = (name: string) => {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${name}=`);
+  if (parts.length === 2) return parts.pop()?.split(";").shift();
+  return null;
+};
+
 const api = axios.create({
+  baseURL: API_BASE_URL || "",
   withCredentials: true,
   headers: {
     "Content-Type": "application/json",
@@ -32,9 +40,11 @@ api.interceptors.response.use(
       originalRequest._retry = true;
 
       try {
+        const refreshToken = getCookie("refresh_token");
+
         const { data } = await axios.post(
           `${API_BASE_URL}${API_PATHS.accounts.refresh}`,
-          {},
+          { refresh_token: refreshToken },
           { withCredentials: true }
         );
 
@@ -45,6 +55,9 @@ api.interceptors.response.use(
         return api(originalRequest);
       } catch (refreshError) {
         useAuthStore.getState().deleteAccessToken();
+        const refreshToken = getCookie("refresh_token");
+        console.log("읽어온 쿠키 전체:", document.cookie);
+        console.log("추출한 리프레시 토큰:", refreshToken);
         return Promise.reject(refreshError);
       }
     }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -36,32 +36,15 @@ export default function Home() {
   const imageRef = useRef<HTMLImageElement>(null);
   const { windowWidth } = useWindowSize();
 
-  const handleNullifyToken = () => {
-    useAuthStore.setState({ accessToken: null });
-    console.log("현재 스토어 상태:", useAuthStore.getState());
-  };
-
   useEffect(() => {
     if (imageRef.current) {
       setImageHeight(imageRef.current.height);
     }
   }, [windowWidth]);
 
-  const handleFetchMe = async () => {
-    try {
-      const response = await api.get(`${API_BASE_URL}${API_PATHS.accounts.me}`);
-      console.log("내 정보 불러오기 성공:", response.data);
-    } catch (error) {
-      console.error("요청 실패:", error);
-      alert("요청에 실패했습니다. 네트워크 탭을 확인하세요.");
-    }
-  };
-
   return (
     <div className="flex flex-col items-center bg-neutral-50 px-5 py-32">
       <div className="flex w-full max-w-5xl flex-col gap-16">
-        <button onClick={handleNullifyToken}>토큰 비우기</button>
-        <button onClick={handleFetchMe}>내 정보 불러오기</button>
         <section className="flex w-full flex-col items-center justify-center gap-16">
           <h1
             key={content + "-text"}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,6 +8,10 @@ import { MainContentSelector } from "@/components";
 import { useWindowSize } from "@/hooks";
 import { useEffect, useRef, useState } from "react";
 
+import api from "@/lib/axios";
+import { API_PATHS, API_BASE_URL } from "@/constants/api-paths";
+import { useAuthStore } from "@/store/useAuthStore";
+
 export type mainContents = "exam" | "qna" | "community";
 
 const MAIN_TEXTS: Record<mainContents, string> = {
@@ -32,15 +36,32 @@ export default function Home() {
   const imageRef = useRef<HTMLImageElement>(null);
   const { windowWidth } = useWindowSize();
 
+  const handleNullifyToken = () => {
+    useAuthStore.setState({ accessToken: null });
+    console.log("현재 스토어 상태:", useAuthStore.getState());
+  };
+
   useEffect(() => {
     if (imageRef.current) {
       setImageHeight(imageRef.current.height);
     }
   }, [windowWidth]);
 
+  const handleFetchMe = async () => {
+    try {
+      const response = await api.get(`${API_BASE_URL}${API_PATHS.accounts.me}`);
+      console.log("내 정보 불러오기 성공:", response.data);
+    } catch (error) {
+      console.error("요청 실패:", error);
+      alert("요청에 실패했습니다. 네트워크 탭을 확인하세요.");
+    }
+  };
+
   return (
     <div className="flex flex-col items-center bg-neutral-50 px-5 py-32">
       <div className="flex w-full max-w-5xl flex-col gap-16">
+        <button onClick={handleNullifyToken}>토큰 비우기</button>
+        <button onClick={handleFetchMe}>내 정보 불러오기</button>
         <section className="flex w-full flex-col items-center justify-center gap-16">
           <h1
             key={content + "-text"}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,10 +8,6 @@ import { MainContentSelector } from "@/components";
 import { useWindowSize } from "@/hooks";
 import { useEffect, useRef, useState } from "react";
 
-import api from "@/lib/axios";
-import { API_PATHS, API_BASE_URL } from "@/constants/api-paths";
-import { useAuthStore } from "@/store/useAuthStore";
-
 export type mainContents = "exam" | "qna" | "community";
 
 const MAIN_TEXTS: Record<mainContents, string> = {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #144 

## 📝작업 내용

> refreshToken을 통한 accessToken 연장 

### 스크린샷
아래에 첨부된 영상은 vite.config.ts 설정에서 api 요청을 보내는 값을 프록시를 통해 https로 변경한 뒤 보낸 요청을 녹화한 상태입니다

https://github.com/user-attachments/assets/5e8fb5bd-eef3-4c55-9c13-3fa4edee0513

### ✅ 이슈 자동 종료

> 이 PR이 머지될 때 자동으로 이슈를 닫으려면 아래에 작성해주세요.
>
> **Closes #144 **
