### PR TITLE
Refactor: 유저 객체에서 프로필 이미지 프로퍼티 삭제

### DIFF
--- a/src/lib/authUtils.ts
+++ b/src/lib/authUtils.ts
@@ -6,12 +6,11 @@ import type { AxiosError } from "axios";
 import type { SignupErrorResponse } from "@/types/api-response-type/auth-response-type";
 
 export const transformUserInfo = (raw: UserInfoResponse): UserInfo => {
-  const { phone_number, profile_img_url, created_at, ...base } = raw;
+  const { phone_number, created_at, ...base } = raw;
 
   return {
     ...base,
     phoneNumber: phone_number,
-    profileImgUrl: profile_img_url,
     createdAt: created_at,
   };
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -49,3 +49,12 @@ export function createCohortsDropdownOptions(
 
   return newCohorts;
 }
+
+export function creatProfileImageUrl(
+  userId: number,
+  size: 64 | 128 | 256 = 128
+) {
+  const s3Domain = import.meta.env.VITE_S3_DOMAIN_URL;
+
+  return `${s3Domain}/uploads/images/user_profile/${userId}/profile${size}.png`;
+}

--- a/src/mocks/data/auth-data.ts
+++ b/src/mocks/data/auth-data.ts
@@ -24,6 +24,5 @@ export const mockUserInfoResponse: UserInfoResponse = {
   phone_number: "010-1234-5678",
   birthday: "1995-01-01",
   gender: "M",
-  profile_img_url: "selife.png",
   created_at: "2025-12-26T00:00:00Z",
 };

--- a/src/types/api-response-type/auth-response-type.ts
+++ b/src/types/api-response-type/auth-response-type.ts
@@ -9,13 +9,11 @@ export interface BaseUserInfo {
 
 export interface UserInfoResponse extends BaseUserInfo {
   phone_number: string;
-  profile_img_url: string;
   created_at: string;
 }
 
 export interface UserInfo extends BaseUserInfo {
   phoneNumber: string;
-  profileImgUrl: string;
   createdAt: string;
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #152

## 📝작업 내용

> 유저 객체에서 프로필 이미지 프로퍼티 삭제

+ 유저 객체에서 프로필 이미지 프로퍼티 삭제
+ createProfileImageUrl 유틸함수 생성

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

+ 아래와 같이 환경 변수 추가해주세요!
```
VITE_S3_DOMAIN_URL=
```

### ✅ 이슈 자동 종료

> 이 PR이 머지될 때 자동으로 이슈를 닫으려면 아래에 작성해주세요.
>
> **Closes #152**
