### PR TITLE
Feature: 쪽지시험 결과 페이지에 시험 문제 결과 컴포넌트 적용

### DIFF
--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -18,6 +18,7 @@ import ExamHeaderTitle from "@/components/ExamHeaderTitle";
 import ExamContentContainer from "@/components/ExamContentContainer";
 import ExamBottomButton from "@/components/ExamBottomButton";
 import QuestionHeader from "@/components/QuestionHeader";
+import ExamQuestionResult from "@/components/questionResult/ExamQuestionResult";
 
 export {
   Footer,
@@ -40,4 +41,5 @@ export {
   ExamContentContainer,
   ExamBottomButton,
   QuestionHeader,
+  ExamQuestionResult,
 };

--- a/src/components/questionResult/ExamQuestionResult.tsx
+++ b/src/components/questionResult/ExamQuestionResult.tsx
@@ -1,0 +1,28 @@
+import { QuestionHeader } from "@/components";
+import type { QuestionResult } from "@/types";
+import { EXAM_QUESTION_RESULT_CONTENT_MAP } from "@/components/questionResult/exam-question-result-content-map";
+import { EXAM_QUESTION_CONTENT_LAYOUT_BASE } from "@/constants";
+
+interface ExamQuestionResultProps {
+  question: QuestionResult;
+}
+
+function ExamQuestionResult({ question }: ExamQuestionResultProps) {
+  const ContentComponent = EXAM_QUESTION_RESULT_CONTENT_MAP[question.type];
+
+  return (
+    <li>
+      <QuestionHeader
+        questionNumber={question.number}
+        question={question.question}
+        point={question.point}
+        type={question.type}
+      />
+      <div className={EXAM_QUESTION_CONTENT_LAYOUT_BASE}>
+        <ContentComponent question={question} />
+      </div>
+    </li>
+  );
+}
+
+export default ExamQuestionResult;

--- a/src/components/questionResult/exam-question-result-content-map.ts
+++ b/src/components/questionResult/exam-question-result-content-map.ts
@@ -1,0 +1,19 @@
+import type { ExamQuestionResultContentComponent, QuestionType } from "@/types";
+import SingleChoice from "@/components/questionResult/SingleChoice";
+import MultipleChoice from "@/components/questionResult/MultipleChoice";
+import ShortAnswer from "@/components/questionResult/ShortAnswer";
+import FillBlank from "@/components/questionResult/FillBlank";
+import Ox from "@/components/questionResult/Ox";
+import Ordering from "@/components/questionResult/Ordering";
+
+export const EXAM_QUESTION_RESULT_CONTENT_MAP: Record<
+  QuestionType,
+  ExamQuestionResultContentComponent
+> = {
+  singleChoice: SingleChoice,
+  multipleChoice: MultipleChoice,
+  shortAnswer: ShortAnswer,
+  fillBlank: FillBlank,
+  ox: Ox,
+  ordering: Ordering,
+};

--- a/src/pages/ExamResult.tsx
+++ b/src/pages/ExamResult.tsx
@@ -3,25 +3,29 @@ import {
   ExamContentContainer,
   ExamHeaderContainer,
   ExamHeaderTitle,
+  ExamQuestionResult,
 } from "@/components";
-import { EXAM_QUESTION_CONTENT_MAP } from "@/components/question/exam-question-content-map";
-import { EXAM_LAYOUT_BASE, EXAM_QUESTION_TYPE_LABEL_MAP } from "@/constants";
+import { LoadingUi } from "@/components/common";
+import { EXAM_LAYOUT_BASE } from "@/constants";
+import { useExamResult } from "@/hooks/api";
 import { cn } from "@/lib";
-import { questionResultList } from "@/mocks/data/exam-data";
-
-const BADGE_BASE =
-  "flex h-6 items-center rounded-xs bg-neutral-200 text-neutral-700";
+import { useParams } from "react-router";
+import { NotFound } from "@/components/common/not-found";
 
 function ExamResult() {
-  const ContentComponent = EXAM_QUESTION_CONTENT_MAP.singleChoice;
+  const params = useParams();
+  const submissionId = Number(params?.submissionId);
+  const { data: exam, isLoading, isError, error } = useExamResult(submissionId);
+  const headerSubText = `총 문항 수: ${exam?.questions.length}ㆍ부정행위: ${exam?.cheatingCount}회ㆍ응시시간: ${exam?.duration.split(":")[1]}분ㆍ응시 결과 점수: ${exam?.score}점/${exam?.totalScore}점`;
 
+  if (isLoading)
+    return <LoadingUi className="mx-auto mt-96 flex w-full justify-center" />;
+  if (isError)
+    return <NotFound statusCode={error.response?.status ?? error.message} />;
   return (
     <>
       <ExamHeaderContainer>
-        <ExamHeaderTitle
-          title="TypeScript 쪽지시험"
-          subText="총 문항 수: 7ㆍ부정행위: 1회ㆍ응시시간: 30분ㆍ응시 결과 점수: 80점/100점"
-        />
+        <ExamHeaderTitle title="TypeScript 쪽지시험" subText={headerSubText} />
       </ExamHeaderContainer>
       <main>
         <div className="bg-primary-100 mt-32 h-29.5 py-7">
@@ -35,42 +39,12 @@ function ExamResult() {
             </span>
           </div>
         </div>
-        {/** TODO 실제 데이터로 교체, 결과 페이지용 컴포넌트로 교체 */}
         <ExamContentContainer>
-          <li>
-            <div className="flex items-start gap-4">
-              <div className="flex max-w-4/5 gap-3 text-xl font-bold">
-                <span>{questionResultList[0].number}.</span>
-                <span className="tracking-tighter break-keep">
-                  {questionResultList[0].question}
-                </span>
-              </div>
-              <div className="mt-0.5 flex gap-2 text-xs font-semibold">
-                <div className={cn("px-2", BADGE_BASE)}>
-                  {questionResultList[0].point}점
-                </div>
-                <div className={cn("px-2.5", BADGE_BASE)}>
-                  {EXAM_QUESTION_TYPE_LABEL_MAP.singleChoice}
-                </div>
-              </div>
-            </div>
-            <div className="pt-5 pl-7">
-              <ContentComponent
-                question={{
-                  ...questionResultList[0],
-                  blankCount: 0,
-                  answerInput: null,
-                  questionId: 1,
-                  type: "singleChoice",
-                }}
-                value={"value"}
-                onChange={() => {}}
-              />
-            </div>
-          </li>
+          {exam?.questions.map((question) => (
+            <ExamQuestionResult key={question.questionId} question={question} />
+          ))}
         </ExamContentContainer>
-        {/**  TODO 마이페이지 레이아웃 추가되면 경로 수정하기*/}
-        <ExamBottomButton type="link" label="완료" to="/exams" />
+        <ExamBottomButton type="link" label="완료" to="/my-page/exams" />
       </main>
     </>
   );

--- a/src/types/exam-types.ts
+++ b/src/types/exam-types.ts
@@ -141,3 +141,10 @@ export interface QuestionResult extends QuestionBase {
   isCorrect: boolean;
   explanation: string; // 빈 문자열이면 없음
 }
+
+interface ExamQuestionResultContentProps {
+  question: QuestionResult;
+}
+
+export type ExamQuestionResultContentComponent =
+  React.FC<ExamQuestionResultContentProps>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ import type {
   QuestionResultDto,
   QuestionResult,
   ResultAnswerValue,
+  ExamQuestionResultContentComponent,
 } from "@/types/exam-types";
 
 export type {
@@ -46,4 +47,5 @@ export type {
   QuestionResultDto,
   QuestionResult,
   ResultAnswerValue,
+  ExamQuestionResultContentComponent,
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #157
## 📝작업 내용

> 쪽지시험 결과 페이지에 시험 문제 결과 컴포넌트 적용

- useExamResult 쿼리 훅 사용해서 데이터 조회
- 시험 문제 결과 컴포넌트 적용

## 스크린샷

https://github.com/user-attachments/assets/2eae5208-77e8-4d32-bd96-accc4d8b6f45

## ✅ 이슈 자동 종료

> **Closes #157**
