### PR TITLE
Fix: 결과 페이지에서 목록 페이지로 이동 시 무한 스크롤 즉시 실행되는 문제 수정

### DIFF
--- a/src/pages/Exams.tsx
+++ b/src/pages/Exams.tsx
@@ -1,6 +1,6 @@
 import { ExamCategorySelector, ExamList } from "@/components";
 import type { ExamCategory } from "@/types";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { NotFound } from "@/components/common/not-found";
 import { LoadingUi } from "@/components/common";
 import { useInfiniteScroll } from "@/hooks";
@@ -33,6 +33,10 @@ function Exams() {
     }) ?? [];
 
   const handleCategoryClick = (category: ExamCategory) => setCategory(category);
+
+  useEffect(() => {
+    scrollTo(0, 0);
+  }, []);
 
   if (isError)
     return <NotFound statusCode={error.response?.status ?? error.message} />;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #164

## 📝작업 내용

> 결과 페이지에서 목록 페이지로 이동 시 무한 스크롤 즉시 실행되는 문제 수정
- 작업 이전
  쪽지시험 결과 페이지에서 화면 하단 버튼을 클릭하여 목록 페이지로 이동하면 무한 스크롤이 즉시 실행됨
- 현재
  목록 페이지 진입 시 스크롤을 항상 화면 최상단으로 이동시켜 무한 스크롤이 즉시 실행되지 않도록 함

## 스크린샷

https://github.com/user-attachments/assets/c0feaeac-05c3-46b3-8f4a-67dc557d8b9f

## ✅ 이슈 자동 종료

> **Closes #164**