### PR TITLE
Fix: 헤더 링크 클릭 시 다른 팀 페이지로 이동되지 않는 문제 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,8 +20,6 @@ function App() {
       <Routes>
         <Route element={<RootLayout />}>
           <Route path="/" element={<Home />} />
-          <Route path="/community" element={<div>커뮤니티 페이지</div>} />
-          <Route path="/qna" element={<div>질의응답 페이지</div>} />
           <Route path="/profile" element={<div>수강생 등록 페이지</div>} />
 
           <Route path="/my-page" element={<MyPageLayout />}>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -26,9 +26,8 @@ export default function Header() {
                   <img src={HeaderLogo} alt="헤더로고" />
                 </div>
               </Link>
-
-              <HeaderLink to="/community">커뮤니티</HeaderLink>
-              <HeaderLink to="/qna">질의응답</HeaderLink>
+              <a href="https://community.ozcodingschool.site">커뮤니티</a>
+              <a href="https://qna.ozcodingschool.site">질의응답</a>
             </nav>
           </div>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #173

## 📝작업 내용

> 헤더 링크 클릭 시 다른 팀 페이지로 이동되지 않는 문제 수정

## 스크린샷

https://github.com/user-attachments/assets/65c1a055-869d-464b-b1bf-e6cab2b7ac09

## ✅ 이슈 자동 종료

> **Closes #173**
