### PR TITLE
Feature: purpose값 추가 및 코드 수정

### DIFF
--- a/src/components/FindEmailModal.tsx
+++ b/src/components/FindEmailModal.tsx
@@ -101,7 +101,7 @@ export default function FindEmailModal({ onClose }: FindEmailModalProps) {
                 />
               </div>
 
-              <SMSVerification onVerify={handleSMSVerify} />
+              <SMSVerification onVerify={handleSMSVerify} purpose="find" />
 
               <Button
                 type="button"

--- a/src/components/FindPasswordModal.tsx
+++ b/src/components/FindPasswordModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useForm, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
@@ -53,6 +53,16 @@ export default function FindPasswordModal({ onClose }: FindPasswordModalProps) {
       );
     },
   });
+
+  useEffect(() => {
+    if (step === 3) {
+      const timer = setTimeout(() => {
+        onClose();
+      }, 5000);
+
+      return () => clearTimeout(timer);
+    }
+  }, [step, onClose]);
 
   const onValidSubmit = (data: FindPasswordType) => {
     if (!emailToken) return;

--- a/src/components/auth/SMSVerification.tsx
+++ b/src/components/auth/SMSVerification.tsx
@@ -7,9 +7,13 @@ import { useToast } from "@/hooks";
 
 interface SMSVerificationProps {
   onVerify: (status: boolean) => void;
+  purpose: "signup" | "find" | "restore";
 }
 
-export default function SMSVerification({ onVerify }: SMSVerificationProps) {
+export default function SMSVerification({
+  onVerify,
+  purpose,
+}: SMSVerificationProps) {
   const {
     register,
     watch,
@@ -19,7 +23,6 @@ export default function SMSVerification({ onVerify }: SMSVerificationProps) {
   } = useFormContext<SMSVerificationSchemaType>();
 
   const [isSMSSent, setIsSMSSent] = useState(false);
-
   const [isVerified, setIsVerified] = useState(false);
 
   const { triggerToast } = useToast();
@@ -56,9 +59,20 @@ export default function SMSVerification({ onVerify }: SMSVerificationProps) {
         variant: "small",
       });
     },
-    onError: () => {
+    onError: (error) => {
+      const errorData = error.response?.data;
+
+      const fieldErrors = errorData?.errors
+        ? Object.values(errorData.errors).flat()[0]
+        : null;
+
+      const serverMessage =
+        fieldErrors ||
+        errorData?.error_detail ||
+        "인증번호 전송에 실패했습니다.";
+
       triggerToast({
-        text: "인증번호 전송에 실패했습니다.",
+        text: serverMessage,
         status: "danger",
         variant: "small",
       });
@@ -76,12 +90,15 @@ export default function SMSVerification({ onVerify }: SMSVerificationProps) {
         variant: "small",
       });
     },
-    onError: () => {
+    onError: (error) => {
       setValue("smscode", "");
       setIsVerified(false);
       onVerify(false);
+
+      const serverMessage =
+        error.response?.data?.error_detail || "인증번호가 일치하지 않습니다.";
       triggerToast({
-        text: "인증번호가 일치하지 않습니다.",
+        text: serverMessage,
         status: "danger",
         variant: "small",
       });
@@ -90,7 +107,7 @@ export default function SMSVerification({ onVerify }: SMSVerificationProps) {
 
   const handleSendCode = () => {
     if (fullPhoneNumber.length >= 10) {
-      sendSMS({ phoneNumber: fullPhoneNumber });
+      sendSMS({ phoneNumber: fullPhoneNumber, purpose: purpose });
     }
   };
 

--- a/src/hooks/api/verification/useSendSMS.ts
+++ b/src/hooks/api/verification/useSendSMS.ts
@@ -3,22 +3,31 @@ import { API_BASE_URL } from "@/constants/api-paths";
 import { api } from "@/lib";
 import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
 import type { AxiosError } from "axios";
+import type { SignupErrorResponse } from "@/types/api-response-type/auth-response-type";
+
+export interface SendSMSMRequest {
+  phoneNumber: string;
+  purpose?: "signup" | "find" | "restore";
+}
 
 type SendSMSMutationOptons = Omit<
-  UseMutationOptions<unknown, AxiosError, { phoneNumber: string }>,
+  UseMutationOptions<unknown, AxiosError<SignupErrorResponse>, SendSMSMRequest>,
   "mutateFn"
 >;
 
 export default function useSendSMS(options?: SendSMSMutationOptons) {
-  return useMutation({
-    mutationFn: async ({ phoneNumber }) => {
-      await api.post(
-        `${API_BASE_URL}${API_PATHS.accounts.verification.sendSMS}`,
-        {
-          phone_number: phoneNumber,
-        }
-      );
-    },
-    ...options,
-  });
+  return useMutation<unknown, AxiosError<SignupErrorResponse>, SendSMSMRequest>(
+    {
+      mutationFn: async ({ phoneNumber, purpose = "find" }) => {
+        await api.post(
+          `${API_BASE_URL}${API_PATHS.accounts.verification.sendSMS}`,
+          {
+            phone_number: phoneNumber,
+            purpose,
+          }
+        );
+      },
+      ...options,
+    }
+  );
 }

--- a/src/hooks/api/verification/useVerifyEmail.ts
+++ b/src/hooks/api/verification/useVerifyEmail.ts
@@ -6,12 +6,13 @@ import type { AxiosError } from "axios";
 import type {
   EmailVerifyServerResponse,
   EmailVerifyResponse,
+  SignupErrorResponse,
 } from "@/types/api-response-type/auth-response-type";
 
 type VerifyEmailMutationOptions = Omit<
   UseMutationOptions<
     EmailVerifyResponse,
-    AxiosError,
+    AxiosError<SignupErrorResponse>,
     { email: string; code: string }
   >,
   "mutateFn"

--- a/src/hooks/api/verification/useVerifySMS.ts
+++ b/src/hooks/api/verification/useVerifySMS.ts
@@ -6,12 +6,13 @@ import type { AxiosError } from "axios";
 import type {
   SMSVerifyServerResponse,
   SMSVerifyResponse,
+  SignupErrorResponse,
 } from "@/types/api-response-type/auth-response-type";
 
 type VerifySMSMutationOptions = Omit<
   UseMutationOptions<
     SMSVerifyResponse,
-    AxiosError,
+    AxiosError<SignupErrorResponse>,
     { phoneNumber: string; code: string }
   >,
   "mutateFn"

--- a/src/pages/EmailSignupPage.tsx
+++ b/src/pages/EmailSignupPage.tsx
@@ -128,9 +128,9 @@ export default function EmailSignupPage() {
             </div>
           </section>
 
-          <EmailVerification onVerify={setIsEmailVerified} />
+          <EmailVerification onVerify={setIsEmailVerified} purpose="signup" />
 
-          <SMSVerification onVerify={setIsSmsVerified} />
+          <SMSVerification onVerify={setIsSmsVerified} purpose="signup" />
 
           <section>
             <div className="flex flex-col gap-2">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #175

## 📝작업 내용

> purpose값 추가 및 코드 수정

- SMS, Email 인증을 사용한 폼 purpose값 추가
- FindPassword 모달 기능명세서에 맞게 5초후에 꺼지도록 설계
- 디테일한 Error메시지가 나오도록 구현

## 전달사항

> 작업을 하면서 타입이 너무 일관성이 없는것을 확인했습니다 어떤 타입은 auth-response-type에 지정해놓고 쓰고 어떤 타입은 파일내에 선언하고 또 어떤건 request타입 선언해서 사용했지만 어떤건 그냥 email: string;과 같이 그냥 썡으로 해놓은거 등등 지금보면 고칠게 한 두가지가 아닌데 현재로써는 기능구현과 기능작동 그리고 PPT에 신경쓸 예정입니다. 시간이 남는다면 타입을 일관성있게 수정하도록 하고 다음 프로젝트에서는 일관성 유지할 수 있도록 해보겠습니다

### 스크린샷 (선택)

## purpose = "signup"
가입된 메일
<img width="943" height="516" alt="image" src="https://github.com/user-attachments/assets/5101f7b6-d28d-4d2d-8328-7f2a3785f553" />

가입된 휴대폰
<img width="942" height="644" alt="image" src="https://github.com/user-attachments/assets/b07d3e8d-8ea3-45be-a7a9-fe14135105df" />

## purpose = "find"
가입되지 않은 메일
<img width="956" height="658" alt="image" src="https://github.com/user-attachments/assets/caccce42-6c5c-4fa5-b073-041ee1812108" />

가입되지 않은 휴대폰
<img width="950" height="739" alt="image" src="https://github.com/user-attachments/assets/795875d2-037d-4de2-9637-4f198f8aba76" />

코드(번호)인증
<img width="676" height="725" alt="image" src="https://github.com/user-attachments/assets/6817cbb7-2d18-4cc6-9591-080195529e2b" />


### ✅ 이슈 자동 종료

> **Closes #175**
