### PR TITLE
Feature: 쪽지시험 목록 조회 API 연결

### DIFF
--- a/src/api/exams.ts
+++ b/src/api/exams.ts
@@ -1,5 +1,7 @@
 import { API_PATHS, MSW_BASE_URL } from "@/constants";
+import { API_BASE_URL } from "@/constants/api-paths";
 import { api } from "@/lib";
+import type { ExamStatus } from "@/types";
 import type { ExamSubmitRequest } from "@/types/api-request-type/exam-request-types";
 import type {
   ExamCheatingResponseDto,
@@ -20,10 +22,12 @@ export const checkExamCode = (
   );
 
 export const getExamList = async (
-  page: number = 1
+  page: number,
+  status: ExamStatus
 ): Promise<ExamListResponseDto> => {
   const response = await api.get(
-    `${MSW_BASE_URL}${API_PATHS.exams.deployments.list(page)}`
+    `${API_BASE_URL}${API_PATHS.exams.deployments.base}`,
+    { params: { page, status } }
   );
 
   return response.data;

--- a/src/components/ExamList.tsx
+++ b/src/components/ExamList.tsx
@@ -46,7 +46,11 @@ function ExamList({ exams }: ExamListProps) {
                   {isDone ? "응시완료" : "미응시"}
                 </div>
               </div>
-              <span className="text-sm">{`${exam.subject.title} ㆍ ${examInfo.score ?? 0}점/${totalScore}점 ㆍ ${examInfo.correctAnswerCount ?? 0}/${questionCount}개 정답`}</span>
+              {isDone ? (
+                <span className="text-sm">{`${exam.subject.title} ㆍ ${examInfo.score ?? 0}점/${totalScore}점 ㆍ ${examInfo.correctAnswerCount ?? 0}/${questionCount}개 정답`}</span>
+              ) : (
+                <span>{`${exam.subject.title} ㆍ 응시하고 점수를 확인해보세요!`}</span>
+              )}
             </div>
             {isDone ? (
               <LinkButton

--- a/src/constants/api-paths.ts
+++ b/src/constants/api-paths.ts
@@ -10,7 +10,6 @@ export const API_PATHS = {
   exams: {
     deployments: {
       base: `${API_PREFIX}/exams/deployments`,
-      list: (page: number) => `${API_PREFIX}/exams/deployments?page=${page}`,
       checkCode: (deploymentId: number) =>
         `${API_PREFIX}/exams/deployments/${deploymentId}/check-code`,
       questionList: (deploymentId: number) =>

--- a/src/hooks/api/useExamList.ts
+++ b/src/hooks/api/useExamList.ts
@@ -9,7 +9,7 @@ import {
 } from "@tanstack/react-query";
 import { getExamList } from "@/api/exams";
 import type { AxiosError } from "axios";
-import type { Exam, ExamDto } from "@/types";
+import type { Exam, ExamDto, ExamStatus } from "@/types";
 
 type ExamListQueryOptions = Omit<
   UseInfiniteQueryOptions<
@@ -20,13 +20,13 @@ type ExamListQueryOptions = Omit<
   "queryKey" | "queryFn" | "initialPageParam" | "getNextPageParam" | "select"
 >;
 
-function useExamList(options?: ExamListQueryOptions) {
+function useExamList(status: ExamStatus, options?: ExamListQueryOptions) {
   return useInfiniteQuery({
-    queryKey: ["exams", "list"] as const,
-    queryFn: ({ pageParam }) => getExamList(pageParam as number),
+    queryKey: ["exams", "list", status] as const,
+    queryFn: ({ pageParam }) => getExamList(pageParam as number, status),
     initialPageParam: 1,
     getNextPageParam: (lastPage) =>
-      lastPage.has_next ? lastPage.page + 1 : undefined,
+      lastPage.next ? lastPage.page + 1 : undefined,
     select: convertExamList,
     ...options,
   });
@@ -38,8 +38,7 @@ const convertExamList = (
   data: InfiniteData<ExamListResponseDto>
 ): InfiniteData<ExamListResponse> => ({
   pages: data.pages.map((item) => ({
-    page: item.page,
-    hasNext: item.has_next,
+    ...item,
     results: item.results.map(convertExam),
   })),
   pageParams: data.pageParams,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,6 +10,7 @@ import useExamCheatingModal from "@/hooks/useExamCheatingModal";
 import useExamAnswers from "@/hooks/useExamAnswers";
 import useExamSubmitControl from "@/hooks/useExamSubmitControl";
 import useExamStatusControl from "@/hooks/useExamStatusControl";
+import useExams from "@/hooks/useExams";
 
 export {
   useToast,
@@ -25,4 +26,5 @@ export {
   useExamAnswers,
   useExamSubmitControl,
   useExamStatusControl,
+  useExams,
 };

--- a/src/hooks/useExams.ts
+++ b/src/hooks/useExams.ts
@@ -1,0 +1,40 @@
+import { useExamList } from "@/hooks/api";
+
+function useExams() {
+  const pendingQuery = useExamList("pending");
+  const doneQuery = useExamList("done");
+
+  const pendingExams = pendingQuery.data?.pages.flatMap((page) => page.results);
+  const doneExams = doneQuery.data?.pages.flatMap((page) => page.results);
+  const allExams = [...(pendingExams ?? []), ...(doneExams ?? [])];
+
+  const isLoading = pendingQuery.isLoading || doneQuery.isLoading;
+  const isError = pendingQuery.isError || doneQuery.isError;
+  // 두 쿼리 모두에서 오류 발생하면 pending 쿼리 오류 우선 표시
+  const error = pendingQuery.error ?? doneQuery.error;
+  const hasNextPage = pendingQuery.hasNextPage || doneQuery.hasNextPage;
+  const isFetchingNextPage =
+    pendingQuery.isFetchingNextPage || doneQuery.isFetchingNextPage;
+
+  const fetchNextPage = () => {
+    if (pendingQuery.hasNextPage && doneQuery.hasNextPage) {
+      pendingQuery.fetchNextPage();
+      doneQuery.fetchNextPage();
+      return;
+    }
+    if (pendingQuery.hasNextPage) return pendingQuery.fetchNextPage();
+    if (doneQuery.hasNextPage) return doneQuery.fetchNextPage();
+  };
+
+  return {
+    data: allExams,
+    isLoading,
+    isError,
+    error,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  };
+}
+
+export default useExams;

--- a/src/mocks/handlers/exam-handlers.ts
+++ b/src/mocks/handlers/exam-handlers.ts
@@ -31,7 +31,10 @@ const getExamListResponse = (page: number): ExamListResponseDto => {
 
   return {
     page,
-    has_next: page < LAST_PAGE,
+    size: PAGE_SIZE,
+    count: results.length,
+    previous: page === 1 ? false : true,
+    next: page < LAST_PAGE,
     results,
   };
 };

--- a/src/pages/Exams.tsx
+++ b/src/pages/Exams.tsx
@@ -3,12 +3,11 @@ import type { ExamCategory } from "@/types";
 import { useEffect, useState } from "react";
 import { NotFound } from "@/components/common/not-found";
 import { LoadingUi } from "@/components/common";
-import { useInfiniteScroll } from "@/hooks";
-import { useExamList } from "@/hooks/api";
+import { useExams, useInfiniteScroll } from "@/hooks";
 
 function Exams() {
   const [category, setCategory] = useState<ExamCategory>("all");
-
+  const isAllSelected = category === "all";
   const {
     data: exams,
     isLoading,
@@ -17,20 +16,18 @@ function Exams() {
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
-  } = useExamList();
+  } = useExams();
 
   const bottomRef = useInfiniteScroll<HTMLDivElement>(
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
-    category === "all"
+    isAllSelected
   );
 
-  const filteredExams =
-    exams?.pages.flatMap((page) => {
-      if (category === "all") return page.results;
-      return page.results.filter((item) => item.examInfo.status === category);
-    }) ?? [];
+  const filteredExams = isAllSelected
+    ? exams
+    : exams.filter((exam) => exam.examInfo.status === category);
 
   const handleCategoryClick = (category: ExamCategory) => setCategory(category);
 
@@ -39,7 +36,7 @@ function Exams() {
   }, []);
 
   if (isError)
-    return <NotFound statusCode={error.response?.status ?? error.message} />;
+    return <NotFound statusCode={error?.response?.status ?? error?.message} />;
   return (
     <section className="flex min-h-dvh flex-col">
       <h1 className="mb-10 text-4xl font-bold">쪽지시험</h1>

--- a/src/types/api-response-type/exam-response-types.ts
+++ b/src/types/api-response-type/exam-response-types.ts
@@ -8,17 +8,18 @@ import type {
   QuestionResultDto,
 } from "@/types";
 
-export interface ExamListResponseDto {
+interface ExamListResponseBase<TExam> {
   page: number;
-  has_next: boolean;
-  results: ExamDto[];
+  size: number;
+  count: number;
+  previous: boolean | null;
+  next: boolean | null;
+  results: TExam[];
 }
 
-export interface ExamListResponse {
-  page: number;
-  hasNext: boolean;
-  results: Exam[];
-}
+export type ExamListResponseDto = ExamListResponseBase<ExamDto>;
+
+export type ExamListResponse = ExamListResponseBase<Exam>;
 
 export interface ExamQuestionListResponseDto {
   exam_id: number;

--- a/src/types/exam-types.ts
+++ b/src/types/exam-types.ts
@@ -20,7 +20,7 @@ export interface ExamDto {
   question_count: number;
   total_score: number;
   exam_info: {
-    status: string;
+    status: ExamStatus;
     score: number | null;
     correct_answer_count: number | null;
   };
@@ -44,7 +44,7 @@ export interface Exam {
   questionCount: number;
   totalScore: number;
   examInfo: {
-    status: string;
+    status: ExamStatus;
     score: number | null;
     correctAnswerCount: number | null;
   };


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #166

## 📝작업 내용
쪽지시험 목록 조회 API 연결
- 쪽지시험 목록 조회 API 연결
- useExams 훅 추가
  -  pending / done 상태인 시험 목록을 각각 조회하여 Exams 페이지에서는 쿼리 훅을 한 번만 호출한 것처럼 사용할 수 있도록 도와주는 훅 입니다.
  - 추가 이유
    1. 본래 쪽지시험 목록 조회 API는 시험 상태에 관계없이 전체 목록을 한 번에 조회할 수 있었으나, 현재는 시험 상태를 지정하여 (pending / done) 한 번에 특정 상태에 해당하는 시험 그룹 하나만 조회할 수 있게 변경되었습니다.
    2. Exams 페이지에 진입하면 사용자는 기본적으로 시험 전체 목록을 보게 됩니다. 따라서 pending / done 둘 중 하나만 요청에 실패하더라도 조회 실패로 봐야 한다고 판단했습니다. 일부만 성공해도 성공으로 치고 UI를 보여준다면, 유저는 본인이 미응시 혹은 응시 시험 중에서 무엇을 못보고 있는지 알 수 없기 때문입니다.

- 미응시 상태인 시험은 점수가 아니라 안내 문구가 나오도록 수정
- MSW 핸들러 수정
이제 사용되지는 않지만 API 응답 타입이 변경되면서 빌드 에러나서 수정했습니다.

## 스크린샷

https://github.com/user-attachments/assets/cf8fabfc-223c-4d8e-891a-1e205c1f5915

## ✅ 이슈 자동 종료

> **Closes #166**
